### PR TITLE
🔒 Harden public feature-request API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ When building a new standalone project:
    ```
 3. Close the GitHub issue → shows as "Done" with "Try it →" button
 
+## Security Notes
+
+- The repo is public, so frontend and backend source code are readable.
+- Secrets live in Azure environment variables, not in the frontend or git.
+- Public APIs must be validated server-side; frontend checks are UX only.
+- See [`SECURITY.md`](./SECURITY.md) for trust boundaries and token guidance.
+
 ## Tech Stack
 
 - **Frontend:** Vanilla HTML/CSS/JS

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# SECURITY.md
+
+## Trust boundaries
+
+This repo is public. That means visitors can read the frontend and backend source code.
+
+That **does not** mean visitors can change production code, environment variables, or GitHub state from browser devtools alone.
+
+### Frontend
+- All HTML/CSS/JS shipped to the browser is public.
+- Visitors can modify it locally in devtools.
+- Frontend validation is for UX only, never for security.
+
+### Backend
+- Azure Functions are the real trust boundary.
+- Only backend code running in Azure can use environment secrets.
+- Secrets must never be exposed to frontend code or committed to git.
+
+## Secrets
+
+The following must stay server-side only:
+- `GITHUB_TOKEN`
+- `ANALYTICS_STORAGE_ACCOUNT`
+- `ANALYTICS_STORAGE_KEY`
+- `ANALYTICS_STATS_TOKEN`
+- Azure deployment tokens / GitHub Actions secrets
+
+## GitHub token guidance
+
+Use a **fine-grained token** with the smallest permissions possible.
+
+Recommended for `GITHUB_TOKEN` used by `/api/feature-request`:
+- **Issues: Read & Write**
+- No repository contents write
+- No admin access
+- No actions/workflows access
+
+If future endpoints need broader permissions, use a separate token scoped only to that job.
+
+## Public endpoint protections
+
+`/api/feature-request` includes:
+- server-side validation
+- length limits
+- honeypot field
+- minimum form-fill time check
+- best-effort per-IP rate limiting
+- generic client errors (no upstream secret leakage)
+
+These are abuse mitigations, not perfect guarantees.
+
+## Operational guidance
+
+- Treat backend PRs as higher risk than frontend-only PRs.
+- Main branch is protected: PRs only.
+- Review environment-variable usage before merging backend changes.
+- Never return secrets from an API response.
+- Never inject secrets into static frontend assets.
+
+## Reporting
+
+If you find a vulnerability, report it privately to the repo owner instead of opening a public issue with exploit details.

--- a/api/feature-request/index.js
+++ b/api/feature-request/index.js
@@ -1,8 +1,87 @@
+const rateLimit = new Map();
+
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const MAX_REQUESTS_PER_WINDOW = 5;
+const MAX_TITLE_LENGTH = 120;
+const MAX_DESCRIPTION_LENGTH = 2000;
+const MAX_NAME_LENGTH = 60;
+const MIN_FORM_FILL_MS = 1500;
+
+function cleanText(value, maxLength) {
+    return String(value || '')
+        .replace(/[\u0000-\u001F\u007F]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, maxLength);
+}
+
+function getClientIp(req) {
+    return req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+        req.headers['x-client-ip'] ||
+        req.headers['client-ip'] ||
+        'unknown';
+}
+
+function cleanupRateLimit(now) {
+    for (const [key, entry] of rateLimit.entries()) {
+        if (now - entry.windowStart > WINDOW_MS) {
+            rateLimit.delete(key);
+        }
+    }
+}
+
 module.exports = async function (context, req) {
-    const title = req.body?.title;
-    const description = req.body?.description;
-    const submitter = req.body?.name || 'Anonymous';
-    
+    if ((req.method || '').toUpperCase() !== 'POST') {
+        context.res = {
+            status: 405,
+            body: { error: 'Method not allowed' }
+        };
+        return;
+    }
+
+    const clientIp = getClientIp(req);
+    const now = Date.now();
+    cleanupRateLimit(now);
+
+    // Best-effort rate limit per IP (instance-local; still useful against casual abuse)
+    const current = rateLimit.get(clientIp);
+    if (!current || now - current.windowStart > WINDOW_MS) {
+        rateLimit.set(clientIp, { count: 1, windowStart: now });
+    } else {
+        current.count += 1;
+        if (current.count > MAX_REQUESTS_PER_WINDOW) {
+            context.res = {
+                status: 429,
+                body: { error: 'Too many requests. Please try again later.' }
+            };
+            return;
+        }
+    }
+
+    const title = cleanText(req.body?.title, MAX_TITLE_LENGTH);
+    const description = cleanText(req.body?.description, MAX_DESCRIPTION_LENGTH);
+    const submitter = cleanText(req.body?.name || 'Anonymous', MAX_NAME_LENGTH) || 'Anonymous';
+    const honeypot = cleanText(req.body?.website, 200);
+    const formStartedAt = Number(req.body?.formStartedAt || 0);
+
+    // Hidden field bots fill, humans won't.
+    if (honeypot) {
+        context.res = {
+            status: 200,
+            body: { success: true }
+        };
+        return;
+    }
+
+    // Light bot friction: instant submissions are suspicious.
+    if (!Number.isFinite(formStartedAt) || now - formStartedAt < MIN_FORM_FILL_MS) {
+        context.res = {
+            status: 400,
+            body: { error: 'Form submitted too quickly. Please try again.' }
+        };
+        return;
+    }
+
     if (!title) {
         context.res = {
             status: 400,
@@ -10,16 +89,25 @@ module.exports = async function (context, req) {
         };
         return;
     }
-    
+
+    if (title.length < 3) {
+        context.res = {
+            status: 400,
+            body: { error: 'Title is too short' }
+        };
+        return;
+    }
+
     const githubToken = process.env.GITHUB_TOKEN;
     if (!githubToken) {
+        context.log.error('Missing GITHUB_TOKEN');
         context.res = {
             status: 500,
             body: { error: 'Server configuration error' }
         };
         return;
     }
-    
+
     const issueBody = `## Feature Request
 
 **Submitted by:** ${submitter}
@@ -45,29 +133,34 @@ ${description || 'No description provided.'}
                 labels: ['feature-request']
             })
         });
-        
+
         if (!response.ok) {
-            const error = await response.text();
+            const errorText = await response.text();
+            context.log.error('GitHub issue creation failed', {
+                status: response.status,
+                body: errorText.slice(0, 1000)
+            });
             context.res = {
-                status: 500,
-                body: { error: 'Failed to create issue', details: error }
+                status: 502,
+                body: { error: 'Failed to create issue' }
             };
             return;
         }
-        
+
         const issue = await response.json();
         context.res = {
             status: 200,
-            body: { 
-                success: true, 
+            body: {
+                success: true,
                 issueNumber: issue.number,
                 issueUrl: issue.html_url
             }
         };
     } catch (err) {
+        context.log.error('Feature request handler failed', err.message);
         context.res = {
             status: 500,
-            body: { error: 'Failed to create issue', details: err.message }
+            body: { error: 'Failed to create issue' }
         };
     }
 };

--- a/index.html
+++ b/index.html
@@ -490,6 +490,16 @@
             min-height: 100px;
         }
 
+        .hp-field {
+            position: absolute !important;
+            left: -9999px !important;
+            opacity: 0 !important;
+            pointer-events: none !important;
+            height: 0 !important;
+            width: 0 !important;
+            overflow: hidden !important;
+        }
+
         .submit-btn {
             width: 100%;
             padding: 0.9rem;
@@ -771,17 +781,22 @@
 
         <div class="form-card">
             <form id="featureForm">
+                <input type="hidden" id="formStartedAt" name="formStartedAt">
+                <div class="form-group hp-field" aria-hidden="true">
+                    <label for="website">Website</label>
+                    <input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+                </div>
                 <div class="form-group">
                     <label for="name">Your name (optional)</label>
-                    <input type="text" id="name" name="name" placeholder="Anonymous">
+                    <input type="text" id="name" name="name" placeholder="Anonymous" maxlength="60">
                 </div>
                 <div class="form-group">
                     <label for="title">What should the bot build? *</label>
-                    <input type="text" id="title" name="title" placeholder="A password generator, a pixel art tool, a snake game..." required>
+                    <input type="text" id="title" name="title" placeholder="A password generator, a pixel art tool, a snake game..." maxlength="120" required>
                 </div>
                 <div class="form-group">
                     <label for="description">Any details?</label>
-                    <textarea id="description" name="description" placeholder="Describe what you have in mind..."></textarea>
+                    <textarea id="description" name="description" placeholder="Describe what you have in mind..." maxlength="2000"></textarea>
                 </div>
                 <button type="submit" class="submit-btn">🚀 Submit Request</button>
             </form>
@@ -921,7 +936,10 @@
         }
 
         // ─── Form Submission ───
-        document.getElementById('featureForm').addEventListener('submit', async (e) => {
+        const featureForm = document.getElementById('featureForm');
+        featureForm.formStartedAt.value = Date.now();
+
+        featureForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const form = e.target;
             const btn = form.querySelector('button');
@@ -939,7 +957,9 @@
                     body: JSON.stringify({
                         name: form.name.value,
                         title: form.title.value,
-                        description: form.description.value
+                        description: form.description.value,
+                        website: form.website.value,
+                        formStartedAt: Number(form.formStartedAt.value)
                     })
                 });
 
@@ -949,6 +969,7 @@
                     status.innerHTML = `✅ Submitted! <a href="${data.issueUrl}" target="_blank">Issue #${data.issueNumber}</a> created — Hans will take a look!`;
                     status.className = 'form-status success';
                     form.reset();
+                    form.formStartedAt.value = Date.now();
                     loadStats(); // Refresh stats
                 } else {
                     throw new Error(data.error || 'Submission failed');


### PR DESCRIPTION
## Why
The public site should not trust the browser. This PR hardens the current anonymous issue-creation endpoint and documents the trust boundary clearly.

## Changes
- Server-side sanitization + length limits for title/name/description
- Honeypot field to catch basic bots
- Minimum form-fill time check to add friction against scripted spam
- Best-effort per-IP rate limiting (instance-local, still useful against casual abuse)
- Generic client-facing errors only; upstream details stay server-side in logs
- New `SECURITY.md` documenting:
  - frontend vs backend trust boundary
  - where secrets are safe vs unsafe
  - recommended GitHub token scope
  - review guidance for backend changes
- README security notes

## What this does *not* solve
- This is not industrial-grade bot protection
- Rate limiting is instance-local, not globally coordinated
- For heavier abuse protection, the next step would be Turnstile/CAPTCHA and/or edge-based rate limiting

## Recommended follow-up
Use a fine-grained GitHub token with **Issues: Read & Write only** for the feature-request function.