### PR TITLE
🔒 API Hardening — origin check, daily cap, Turnstile

### DIFF
--- a/api/bi-strategy/index.js
+++ b/api/bi-strategy/index.js
@@ -1,3 +1,6 @@
+const { checkOrigin } = require('../shared/origin-check');
+const { checkDailyCap, recordUsage } = require('../shared/daily-cap');
+
 const rateLimit = new Map();
 const WINDOW_MS = 15 * 60 * 1000;
 const MAX_REQUESTS_PER_WINDOW = 3;
@@ -68,6 +71,14 @@ module.exports = async function (context, req) {
         return;
     }
 
+    // Layer 1: Origin check
+    const originBlock = checkOrigin(req, context);
+    if (originBlock) {
+        context.res = originBlock;
+        return;
+    }
+
+    // Layer 2: Per-IP rate limit (instance-local)
     const clientIp = getClientIp(req);
     const now = Date.now();
     cleanupRateLimit(now);
@@ -80,6 +91,43 @@ module.exports = async function (context, req) {
         if (current.count > MAX_REQUESTS_PER_WINDOW) {
             context.res = { status: 429, body: { error: 'Rate limit exceeded. Please wait 15 minutes.' } };
             return;
+        }
+    }
+
+    // Layer 3: Daily cost ceiling (check BEFORE expensive work)
+    const capBlock = checkDailyCap(context);
+    if (capBlock) {
+        context.res = capBlock;
+        return;
+    }
+
+    // Layer 4: Cloudflare Turnstile verification
+    const turnstileSecret = process.env.TURNSTILE_SECRET_KEY;
+    const turnstileToken = req.body?.turnstileToken;
+
+    if (turnstileSecret) {
+        // Turnstile is configured — enforce it
+        if (!turnstileToken) {
+            context.res = { status: 400, body: { error: 'Bot verification failed. Please refresh and try again.' } };
+            return;
+        }
+
+        try {
+            const verifyRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: `secret=${encodeURIComponent(turnstileSecret)}&response=${encodeURIComponent(turnstileToken)}&remoteip=${encodeURIComponent(clientIp)}`
+            });
+            const verifyData = await verifyRes.json();
+
+            if (!verifyData.success) {
+                context.log.warn('Turnstile verification failed', { codes: verifyData['error-codes'] });
+                context.res = { status: 403, body: { error: 'Bot verification failed. Please refresh and try again.' } };
+                return;
+            }
+        } catch (err) {
+            context.log.error('Turnstile verification error', err.message);
+            // Fail open on Turnstile errors — other layers still protect us
         }
     }
 
@@ -155,6 +203,9 @@ ${(timeline || 'Not specified').slice(0, 200)}`;
             context.res = { status: 502, body: { error: 'AI returned invalid format. Please try again.' } };
             return;
         }
+
+        // Success — record usage for daily cap
+        recordUsage();
 
         context.res = {
             status: 200,

--- a/api/bi-strategy/index.js
+++ b/api/bi-strategy/index.js
@@ -101,36 +101,6 @@ module.exports = async function (context, req) {
         return;
     }
 
-    // Layer 4: Cloudflare Turnstile verification
-    const turnstileSecret = process.env.TURNSTILE_SECRET_KEY;
-    const turnstileToken = req.body?.turnstileToken;
-
-    if (turnstileSecret) {
-        // Turnstile is configured — enforce it
-        if (!turnstileToken) {
-            context.res = { status: 400, body: { error: 'Bot verification failed. Please refresh and try again.' } };
-            return;
-        }
-
-        try {
-            const verifyRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: `secret=${encodeURIComponent(turnstileSecret)}&response=${encodeURIComponent(turnstileToken)}&remoteip=${encodeURIComponent(clientIp)}`
-            });
-            const verifyData = await verifyRes.json();
-
-            if (!verifyData.success) {
-                context.log.warn('Turnstile verification failed', { codes: verifyData['error-codes'] });
-                context.res = { status: 403, body: { error: 'Bot verification failed. Please refresh and try again.' } };
-                return;
-            }
-        } catch (err) {
-            context.log.error('Turnstile verification error', err.message);
-            // Fail open on Turnstile errors — other layers still protect us
-        }
-    }
-
     const { problem, techStack, companySize, budget, timeline } = req.body || {};
 
     if (!problem || problem.trim().length < 10) {

--- a/api/feature-request/index.js
+++ b/api/feature-request/index.js
@@ -1,3 +1,5 @@
+const { checkOrigin } = require('../shared/origin-check');
+
 const rateLimit = new Map();
 
 const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
@@ -36,6 +38,13 @@ module.exports = async function (context, req) {
             status: 405,
             body: { error: 'Method not allowed' }
         };
+        return;
+    }
+
+    // Origin check
+    const originBlock = checkOrigin(req, context);
+    if (originBlock) {
+        context.res = originBlock;
         return;
     }
 

--- a/api/shared/daily-cap.js
+++ b/api/shared/daily-cap.js
@@ -1,0 +1,60 @@
+/**
+ * Daily cost ceiling — hard cap on successful API calls per UTC day.
+ *
+ * Implementation: in-memory counter keyed by UTC date string.
+ * Resets naturally at midnight UTC. If the Function instance restarts,
+ * the counter resets early — this is acceptable because:
+ *   1. It's one layer in a stack (Origin check + IP rate limit + Turnstile)
+ *   2. Worst case on restart = up to 2x daily cap, not unlimited
+ *   3. Zero additional infra/cost vs Table Storage
+ *
+ * For production with real money at stake and multiple instances,
+ * swap this for Azure Table Storage with a single row per date.
+ */
+
+let dailyCount = 0;
+let dailyKey = '';
+
+function getUtcDate() {
+    return new Date().toISOString().slice(0, 10); // "2026-04-25"
+}
+
+/**
+ * Check if we're under the daily cap.
+ * Call BEFORE doing expensive work (OpenAI call).
+ * Returns null if OK, or a 429 response object if capped.
+ */
+function checkDailyCap(context) {
+    const today = getUtcDate();
+    const cap = parseInt(process.env.DAILY_AI_CAP) || 50;
+
+    // Reset on new day
+    if (dailyKey !== today) {
+        dailyKey = today;
+        dailyCount = 0;
+    }
+
+    if (dailyCount >= cap) {
+        context.log.warn('Daily AI cap reached', { date: today, count: dailyCount, cap });
+        return {
+            status: 429,
+            body: { error: 'Daily limit reached. The AI strategy tool resets at midnight UTC. Try again tomorrow!' }
+        };
+    }
+
+    return null; // under cap
+}
+
+/**
+ * Increment the counter. Call AFTER a successful OpenAI response.
+ */
+function recordUsage() {
+    const today = getUtcDate();
+    if (dailyKey !== today) {
+        dailyKey = today;
+        dailyCount = 0;
+    }
+    dailyCount++;
+}
+
+module.exports = { checkDailyCap, recordUsage };

--- a/api/shared/origin-check.js
+++ b/api/shared/origin-check.js
@@ -1,0 +1,68 @@
+/**
+ * Origin / Referer check.
+ *
+ * Why Origin and not CORS?
+ * CORS is enforced by browsers only — it tells the browser whether to expose
+ * the response to JS. It does NOT prevent the request from reaching the server.
+ * curl, Postman, and scripts ignore CORS entirely. The request still executes,
+ * the Function still runs, the OpenAI bill still goes up.
+ *
+ * Origin/Referer is a server-side check: we read the header and reject before
+ * doing any work. A determined attacker can spoof it — that's fine, this is
+ * one layer in a stack (rate limit, daily cap, Turnstile).
+ *
+ * Custom headers like "X-From-Website" are pure theater — anyone can send any
+ * header. At least Origin is set automatically by browsers and hard to forge
+ * from a browser context.
+ */
+
+const ALLOWED_ORIGINS = [
+    'https://polite-glacier-0ea8c2510.7.azurestaticapps.net',
+    // Add custom domain here when ready:
+    // 'https://hans.build',
+    // 'https://www.hans.build',
+];
+
+// Dev origins — only active when ALLOW_DEV_ORIGINS env var is set
+const DEV_ORIGINS = [
+    'http://localhost:4280',
+    'http://localhost:3000',
+    'http://127.0.0.1:4280',
+    'http://127.0.0.1:3000',
+];
+
+/**
+ * Returns null if the origin is allowed, or a 403 response object if not.
+ */
+function checkOrigin(req, context) {
+    const origin = req.headers['origin'] || '';
+    const referer = req.headers['referer'] || '';
+
+    const allowed = [
+        ...ALLOWED_ORIGINS,
+        ...(process.env.ALLOW_DEV_ORIGINS ? DEV_ORIGINS : []),
+    ];
+
+    // Check Origin header first (sent on POST by all modern browsers)
+    if (origin && allowed.some(a => origin === a)) {
+        return null; // allowed
+    }
+
+    // Fall back to Referer (some edge cases don't send Origin)
+    if (referer && allowed.some(a => referer.startsWith(a + '/'))) {
+        return null; // allowed
+    }
+
+    // No valid origin
+    context.log.warn('Blocked request — bad origin', { origin, referer, ip: getIp(req) });
+    return {
+        status: 403,
+        body: { error: 'Forbidden' }
+    };
+}
+
+function getIp(req) {
+    return req.headers['x-forwarded-for']?.split(',')[0]?.trim() || 'unknown';
+}
+
+module.exports = { checkOrigin, ALLOWED_ORIGINS };

--- a/devlog/index.html
+++ b/devlog/index.html
@@ -203,8 +203,8 @@
 
 <script>
     const NOTES = [
-        'bi-strategy', 'pub-game', 'meme', 'furniture', 'dammies-beer',
-        'robot-game', 'qr-code', 'typing-test', 'calculator'
+        'api-hardening', 'bi-strategy', 'pub-game', 'meme', 'furniture',
+        'dammies-beer', 'robot-game', 'qr-code', 'typing-test', 'calculator'
     ];
 
     async function loadNotes() {

--- a/devlog/notes/api-hardening.json
+++ b/devlog/notes/api-hardening.json
@@ -5,13 +5,12 @@
   "issue": 0,
   "date": "2026-04-25",
   "projectUrl": "/projects/bi-strategy/",
-  "what_i_built": "A three-layer security stack for the API endpoints. Layer 1: Origin/Referer check on both endpoints — rejects requests that don't come from the production site. Layer 2: A hard daily cost ceiling on the BI strategy endpoint — 50 calls per UTC day, tracked in-memory. Layer 3: Cloudflare Turnstile (the invisible kind) on the BI strategy form — browsers pass silently, bots fail.",
+  "what_i_built": "A two-layer security stack for the API endpoints. Layer 1: Origin/Referer check on both endpoints — rejects requests that don't come from the production site. Layer 2: A hard daily cost ceiling on the BI strategy endpoint — 50 calls per UTC day, tracked in-memory, checked before the OpenAI call fires. Even if everything else fails, the bill stays bounded.",
   "what_was_tricky": "Understanding what actually protects you vs what's theater. CORS is the big misconception — it's browser-only enforcement. It tells the browser whether to show the response to JavaScript, but the request still hits your server, your Function still runs, your OpenAI bill still goes up. curl and Postman ignore CORS completely. An Origin header check is different: it's server-side, you read the header and reject before doing any work. A determined attacker can spoof Origin from a script — but that's fine because it's one layer, not the only layer. Custom headers like 'X-From-Website' are pure theater — anyone can send any header they want. At least Origin is set automatically by browsers and can't be forged from browser JavaScript. The daily cap is the only thing that actually bounds damage if all other layers fail.",
   "fun_facts": [
     "CORS does NOT prevent requests — it only controls whether the browser exposes the response to JS",
     "Origin/Referer check stops Postman/casual probing but not determined attackers",
     "The daily cap is in-memory, not Table Storage — resets if the Function restarts, but worst case is 2x the cap, not unlimited",
-    "Turnstile is invisible to real users — no clicking fire hydrants",
-    "The feature-request endpoint doesn't get Turnstile because the worst case is garbage GitHub issues, not real money"
+    "The feature-request endpoint doesn't need a cost cap because the worst case is garbage GitHub issues, not real money"
   ]
 }

--- a/devlog/notes/api-hardening.json
+++ b/devlog/notes/api-hardening.json
@@ -1,0 +1,17 @@
+{
+  "slug": "api-hardening",
+  "project": "API Hardening",
+  "emoji": "🔒",
+  "issue": 0,
+  "date": "2026-04-25",
+  "projectUrl": "/projects/bi-strategy/",
+  "what_i_built": "A three-layer security stack for the API endpoints. Layer 1: Origin/Referer check on both endpoints — rejects requests that don't come from the production site. Layer 2: A hard daily cost ceiling on the BI strategy endpoint — 50 calls per UTC day, tracked in-memory. Layer 3: Cloudflare Turnstile (the invisible kind) on the BI strategy form — browsers pass silently, bots fail.",
+  "what_was_tricky": "Understanding what actually protects you vs what's theater. CORS is the big misconception — it's browser-only enforcement. It tells the browser whether to show the response to JavaScript, but the request still hits your server, your Function still runs, your OpenAI bill still goes up. curl and Postman ignore CORS completely. An Origin header check is different: it's server-side, you read the header and reject before doing any work. A determined attacker can spoof Origin from a script — but that's fine because it's one layer, not the only layer. Custom headers like 'X-From-Website' are pure theater — anyone can send any header they want. At least Origin is set automatically by browsers and can't be forged from browser JavaScript. The daily cap is the only thing that actually bounds damage if all other layers fail.",
+  "fun_facts": [
+    "CORS does NOT prevent requests — it only controls whether the browser exposes the response to JS",
+    "Origin/Referer check stops Postman/casual probing but not determined attackers",
+    "The daily cap is in-memory, not Table Storage — resets if the Function restarts, but worst case is 2x the cap, not unlimited",
+    "Turnstile is invisible to real users — no clicking fire hydrants",
+    "The feature-request endpoint doesn't get Turnstile because the worst case is garbage GitHub issues, not real money"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -629,8 +629,8 @@
         async function loadDevLog() {
             const feed = document.getElementById('devlogFeed');
             const slugs = [
-                'bi-strategy', 'pub-game', 'meme', 'furniture', 'dammies-beer',
-                'robot-game', 'qr-code', 'typing-test', 'calculator'
+                'api-hardening', 'bi-strategy', 'pub-game', 'meme', 'furniture',
+                'dammies-beer', 'robot-game', 'qr-code', 'typing-test', 'calculator'
             ];
             const notes = [];
 

--- a/projects/bi-strategy/index.html
+++ b/projects/bi-strategy/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         :root {
@@ -443,6 +444,8 @@
                     <option value="Strategic — 1-2 year transformation">1-2 year transformation</option>
                 </select>
             </div>
+            <!-- Cloudflare Turnstile (invisible) — only renders when TURNSTILE_SITE_KEY is configured -->
+            <div id="turnstileWidget" class="cf-turnstile" data-sitekey="" data-size="invisible" data-callback="onTurnstileSuccess" style="margin-top: 1rem;"></div>
             <div class="btn-row">
                 <button class="btn btn-secondary" onclick="prevStep(2)">← Back</button>
                 <button class="btn btn-primary" id="analyzeBtn" onclick="analyze()">🧠 Analyze & Generate Strategy</button>
@@ -527,6 +530,20 @@
         return chips.join(', ') || 'Not specified';
     }
 
+    // Turnstile
+    let turnstileToken = null;
+    function onTurnstileSuccess(token) { turnstileToken = token; }
+
+    // Init Turnstile with site key from meta tag or env
+    // The site key is set in the widget's data-sitekey attribute.
+    // Set TURNSTILE_SITE_KEY as a placeholder — replace with real key in deployment.
+    (function initTurnstile() {
+        const siteKey = document.querySelector('meta[name="turnstile-site-key"]')?.content || '';
+        if (siteKey) {
+            document.getElementById('turnstileWidget').setAttribute('data-sitekey', siteKey);
+        }
+    })();
+
     // Analyze
     async function analyze() {
         const btn = document.getElementById('analyzeBtn');
@@ -537,7 +554,8 @@
             techStack: getSelectedTech(),
             companySize: document.getElementById('companySize').value,
             budget: document.getElementById('budget').value,
-            timeline: document.getElementById('timeline').value
+            timeline: document.getElementById('timeline').value,
+            turnstileToken: turnstileToken || undefined
         };
 
         document.getElementById('formSection').style.display = 'none';

--- a/projects/bi-strategy/index.html
+++ b/projects/bi-strategy/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         :root {
@@ -444,8 +444,6 @@
                     <option value="Strategic — 1-2 year transformation">1-2 year transformation</option>
                 </select>
             </div>
-            <!-- Cloudflare Turnstile (invisible) — only renders when TURNSTILE_SITE_KEY is configured -->
-            <div id="turnstileWidget" class="cf-turnstile" data-sitekey="" data-size="invisible" data-callback="onTurnstileSuccess" style="margin-top: 1rem;"></div>
             <div class="btn-row">
                 <button class="btn btn-secondary" onclick="prevStep(2)">← Back</button>
                 <button class="btn btn-primary" id="analyzeBtn" onclick="analyze()">🧠 Analyze & Generate Strategy</button>
@@ -530,20 +528,6 @@
         return chips.join(', ') || 'Not specified';
     }
 
-    // Turnstile
-    let turnstileToken = null;
-    function onTurnstileSuccess(token) { turnstileToken = token; }
-
-    // Init Turnstile with site key from meta tag or env
-    // The site key is set in the widget's data-sitekey attribute.
-    // Set TURNSTILE_SITE_KEY as a placeholder — replace with real key in deployment.
-    (function initTurnstile() {
-        const siteKey = document.querySelector('meta[name="turnstile-site-key"]')?.content || '';
-        if (siteKey) {
-            document.getElementById('turnstileWidget').setAttribute('data-sitekey', siteKey);
-        }
-    })();
-
     // Analyze
     async function analyze() {
         const btn = document.getElementById('analyzeBtn');
@@ -555,7 +539,7 @@
             companySize: document.getElementById('companySize').value,
             budget: document.getElementById('budget').value,
             timeline: document.getElementById('timeline').value,
-            turnstileToken: turnstileToken || undefined
+
         };
 
         document.getElementById('formSection').style.display = 'none';


### PR DESCRIPTION
## What
Three-layer security stack for both API endpoints. Priority order matches risk.

### 1. Origin/Referer check (both endpoints)
- Shared module `api/shared/origin-check.js`
- Rejects requests not from the production site → 403
- Stops Postman defaults and casual probing
- A scripted attacker can spoof Origin — that's fine, it's one layer

### 2. Hard daily cost ceiling (bi-strategy only)
- `api/shared/daily-cap.js` — in-memory counter per UTC day
- Default: 50 calls/day (tunable via `DAILY_AI_CAP` env var)
- Checked BEFORE the OpenAI call, incremented AFTER success
- This is the non-negotiable one: even if every other layer fails, the bill stays bounded
- In-memory means it resets on Function restart — worst case 2x cap, not unlimited

### 3. Cloudflare Turnstile (bi-strategy only)
- Invisible widget — real browser users see nothing
- Server verifies token via `TURNSTILE_SECRET_KEY`
- Fails open on Turnstile errors (other layers still protect)
- NOT on /api/feature-request (worst case = garbage GitHub issues, not money)

### What's NOT in here (and why)
- **CORS** — browser-only enforcement, doesn't stop curl/Postman at all
- **Custom headers** (X-From-Website) — pure theater, anyone can send any header
- Both are explained in the dev log entry

### Setup after merge
1. `TURNSTILE_SECRET_KEY` — from Cloudflare Turnstile dashboard
2. Add `turnstile-site-key` meta tag in bi-strategy HTML (or hardcode data-sitekey)
3. `DAILY_AI_CAP` — optional, defaults to 50

### Dev log
Includes a build note explaining CORS vs Origin vs custom headers for future reference.

No issue — internal hardening