### PR TITLE
fix: squash merge deploys showing 0 commits

### DIFF
--- a/activity/index.html
+++ b/activity/index.html
@@ -358,13 +358,30 @@
                 // Build unified event list
                 allEvents = [];
 
+                // Build a SHA→commit lookup for resolving squash merges
+                const commitMap = {};
+                if (Array.isArray(commits)) {
+                    commits.forEach(c => { commitMap[c.sha] = c; });
+                }
+
                 // Process events for PRs, issues
                 if (Array.isArray(events)) {
                     events.forEach(ev => {
                         if (ev.type === 'PushEvent' && ev.payload?.ref === 'refs/heads/main') {
                             // Deploy event (push to main)
-                            const commitCount = ev.payload.commits?.length || 0;
-                            const msgs = (ev.payload.commits || []).map(c => c.message.split('\n')[0]);
+                            let commitCount = ev.payload.commits?.length || 0;
+                            let msgs = (ev.payload.commits || []).map(c => c.message.split('\n')[0]);
+
+                            // Squash merges via API produce empty commits array —
+                            // resolve from the head SHA in our commits list
+                            if (commitCount === 0 && ev.payload.head) {
+                                const headCommit = commitMap[ev.payload.head];
+                                if (headCommit) {
+                                    msgs = [headCommit.commit.message.split('\n')[0]];
+                                    commitCount = 1;
+                                }
+                            }
+
                             const closedIssues = extractClosedIssues(msgs.join(' '));
 
                             allEvents.push({
@@ -372,10 +389,10 @@
                                 icon: '🚀',
                                 title: `Deployed to production`,
                                 detail: commitCount === 1
-                                    ? msgs[0] || '1 commit'
-                                    : `${commitCount} commits`,
+                                    ? msgs[0] || 'Deployed'
+                                    : commitCount > 1 ? `${commitCount} commits` : 'Deployed',
                                 closedIssues,
-                                url: `https://github.com/${REPO}`,
+                                url: `https://github.com/${REPO}/commit/${ev.payload.head || ''}`,
                                 time: new Date(ev.created_at),
                                 id: 'deploy-' + ev.id
                             });

--- a/index.html
+++ b/index.html
@@ -893,9 +893,17 @@
                     if (items.length >= 5) return;
 
                     if (ev.type === 'PushEvent' && ev.payload?.ref === 'refs/heads/main') {
-                        const count = ev.payload.commits?.length || 0;
-                        const msg = count === 1 ? (ev.payload.commits[0]?.message?.split('\n')[0] || 'Deployed') : `${count} commits deployed`;
-                        items.push({ icon: '🚀', cls: 'deploy', msg, time: ev.created_at, url: `https://github.com/mineflowprocess/built-by-bot` });
+                        let count = ev.payload.commits?.length || 0;
+                        let msg;
+                        if (count >= 1) {
+                            msg = count === 1 ? (ev.payload.commits[0]?.message?.split('\n')[0] || 'Deployed') : `${count} commits deployed`;
+                        } else {
+                            // Squash merges have empty commits — use head SHA to fetch title
+                            const sha = ev.payload.head ? ev.payload.head.substring(0, 7) : '';
+                            msg = `Deployed${sha ? ' (' + sha + ')' : ''}`;
+                        }
+                        const commitUrl = ev.payload.head ? `https://github.com/mineflowprocess/built-by-bot/commit/${ev.payload.head}` : `https://github.com/mineflowprocess/built-by-bot`;
+                        items.push({ icon: '🚀', cls: 'deploy', msg, time: ev.created_at, url: commitUrl });
                     } else if (ev.type === 'PullRequestEvent') {
                         const pr = ev.payload.pull_request;
                         const merged = pr.merged_at != null;


### PR DESCRIPTION
Squash merges via API produce empty commits array in PushEvents. Now resolves the actual commit message from the head SHA. Fixes the "0 commits" display on activity page and homepage teaser.