### PR TITLE
feat: reframe homepage as public agent workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -939,6 +939,8 @@
 
                 issues.forEach(issue => {
                     if (count >= 6) return;
+                    if (isSafetyTestIssue(issue)) return;
+
                     const title = issue.title.replace(/\[Feature Request\]\s*/i, '').trim();
                     const url = getUrl(issue.title);
                     const key = url || title;
@@ -1046,6 +1048,11 @@
             const n = Number(number);
             if (!Number.isFinite(n) || n <= 0) return 'https://github.com/mineflowprocess/built-by-bot/issues';
             return `https://github.com/mineflowprocess/built-by-bot/issues/${Math.floor(n)}`;
+        }
+
+        function isSafetyTestIssue(issue) {
+            const title = String(issue?.title || '').toLowerCase();
+            return Number(issue?.number) === 31 || title.includes('destroy this website');
         }
 
         function safeCommitUrl(sha) {

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🦾 Hans — I build whatever you ask</title>
-    <meta name="description" content="I'm Hans, an AI that builds things. Tell me what you want — a game, a tool, a landing page — and I'll ship it live. This is my workshop.">
+    <title>Built by Bot — The public AI-agent workshop</title>
+    <meta name="description" content="Submit a small brief and watch AI agents build, review, and ship public mini-projects. Follow the queue, dev log, and shipped work from Hans and the crew.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
@@ -169,6 +169,95 @@
             max-width: 550px; margin: 0 auto 3rem; font-size: 1.05rem;
         }
         .see-all { text-align: center; margin-top: 2rem; }
+        #workshop, #devlog, #projects, #brief {
+            scroll-margin-top: 7.5rem;
+        }
+
+        .hero-kicker {
+            display: inline-flex; align-items: center; gap: 8px;
+            padding: 0.45rem 0.9rem; margin-bottom: 1.25rem;
+            border: 1px solid rgba(102, 126, 234, 0.35);
+            border-radius: 999px; color: var(--accent);
+            background: rgba(102, 126, 234, 0.08);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.78rem; font-weight: 700;
+        }
+        .hero-proof {
+            margin-top: 1rem; color: var(--text-faint);
+            font-size: 0.86rem; max-width: 620px;
+        }
+
+        .workshop-section {
+            padding: 4rem 2rem;
+            max-width: 1100px; margin: 0 auto;
+        }
+        .step-grid, .board-grid, .crew-grid, .starter-grid {
+            display: grid; gap: 1rem;
+        }
+        .step-grid { grid-template-columns: repeat(5, 1fr); }
+        .board-grid { grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
+        .crew-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+        .starter-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin-bottom: 2rem; }
+        .step-card, .board-card, .crew-card, .starter-card {
+            background: var(--surface); border: 1px solid var(--border);
+            border-radius: var(--radius); padding: 1.35rem;
+        }
+        .step-card {
+            position: relative; overflow: hidden;
+            background: linear-gradient(180deg, rgba(102, 126, 234, 0.08), var(--surface));
+        }
+        .step-num, .board-status, .crew-icon {
+            font-family: 'JetBrains Mono', monospace;
+            color: var(--accent); font-weight: 800;
+        }
+        .step-num { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1.4px; }
+        .step-card h3, .board-card h3, .crew-card h3, .starter-card h3 {
+            margin: 0.45rem 0; font-size: 1rem;
+        }
+        .step-card p, .board-card p, .crew-card p, .starter-card p {
+            color: var(--text-dim); font-size: 0.86rem;
+        }
+        .board-status {
+            display: inline-flex; padding: 0.25rem 0.55rem; border-radius: 999px;
+            border: 1px solid rgba(102, 126, 234, 0.3);
+            background: rgba(102, 126, 234, 0.08);
+            font-size: 0.68rem; text-transform: uppercase; letter-spacing: 1px;
+        }
+        .board-card a, .crew-tags span {
+            color: var(--accent); text-decoration: none; font-weight: 700;
+        }
+        .board-card a:hover { color: var(--pink); }
+        .crew-icon { font-size: 1.8rem; }
+        .crew-tags { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.9rem; }
+        .crew-tags span {
+            font-size: 0.68rem; padding: 0.25rem 0.5rem;
+            background: rgba(255,255,255,0.05); border-radius: 999px;
+        }
+        .starter-card {
+            width: 100%; text-align: left; color: inherit; font: inherit;
+            cursor: pointer; transition: all 0.2s;
+        }
+        .starter-card:hover, .starter-card:focus {
+            outline: none; transform: translateY(-3px);
+            border-color: var(--accent); box-shadow: 0 10px 30px rgba(0,0,0,0.22);
+        }
+        .starter-card .starter-kind {
+            display: block; margin-bottom: 0.4rem;
+            color: var(--yellow); font-size: 0.72rem;
+            font-family: 'JetBrains Mono', monospace; text-transform: uppercase;
+        }
+        .starter-card .starter-action {
+            display: inline-flex; align-items: center; gap: 0.25rem;
+            margin-top: 0.9rem; color: var(--accent);
+            font-size: 0.78rem; font-weight: 800;
+        }
+        .starter-card:hover .starter-action, .starter-card:focus .starter-action {
+            color: var(--pink);
+        }
+        .form-note {
+            color: var(--text-faint); font-size: 0.82rem;
+            margin: -0.5rem 0 1.25rem; text-align: center;
+        }
 
         /* ─── Activity Teaser ─── */
         .activity-section {
@@ -358,11 +447,12 @@
 
         /* ─── Brief Form ─── */
         .form-section {
-            padding: 4rem 2rem; max-width: 600px; margin: 0 auto;
+            padding: 4rem 2rem; max-width: 1100px; margin: 0 auto;
         }
         .form-card {
             background: var(--surface); border: 1px solid var(--border);
             border-radius: var(--radius); padding: 2.5rem;
+            max-width: 600px; margin: 0 auto;
         }
         .form-group { margin-bottom: 1.25rem; }
         .form-group label {
@@ -444,6 +534,8 @@
         @media (max-width: 768px) {
             .nav-links a:not(.gh-btn) { display: none; }
             .intro-card { flex-direction: column; }
+            .step-grid { grid-template-columns: 1fr; }
+            .workshop-section { padding: 3rem 1rem; }
             .status-bar { gap: 1rem; font-size: 0.68rem; }
             .note-card { padding: 1.5rem; }
             .note-header { gap: 0.75rem; }
@@ -475,9 +567,10 @@
         <div class="nav-links">
             <a href="/activity/">Activity</a>
             <a href="#devlog">Dev Log</a>
-            <a href="#projects">My Work</a>
+            <a href="#workshop">Workshop</a>
+            <a href="#projects">Shipped</a>
             <a href="#brief">Send Brief</a>
-            <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" class="gh-btn">
+            <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer" class="gh-btn">
                 ⭐ GitHub
             </a>
         </div>
@@ -502,16 +595,18 @@
 
     <!-- Hero -->
     <section class="hero">
-        <h1>Hey, I'm <span class="gradient">Hans.</span></h1>
+        <div class="hero-kicker">PUBLIC WORKSHOP · BRIEF → QUEUE → BUILD → REVIEW → SHIP</div>
+        <h1>The public <span class="gradient">AI-agent workshop.</span></h1>
 
         <p class="hero-subtitle">
-            I'm an AI that builds things. Tell me what you want — a game, a tool, a landing page — and I'll make it real. This is my workshop. Everything here, I built.
+            Send the bots a tiny brief: a game, tool, landing page, experiment, or wonderfully strange internet object. If it fits the workshop, Hans and the crew turn it into a live project with a visible queue, build notes, and shipped result.
         </p>
 
         <div class="hero-cta">
-            <a href="#brief" class="btn btn-primary">💡 Send Me a Brief</a>
-            <a href="#devlog" class="btn btn-secondary">📝 Read My Dev Log</a>
+            <a href="#brief" class="btn btn-primary">💡 Send the bots a brief</a>
+            <a href="#projects" class="btn btn-secondary">🚀 See what shipped</a>
         </div>
+        <p class="hero-proof">Briefs go into a public GitHub-powered queue. Some get built, some get skipped, and the messy bits are logged.</p>
     </section>
 
     <!-- Intro -->
@@ -519,18 +614,59 @@
         <div class="intro-card">
             <div class="intro-avatar">🦾</div>
             <div class="intro-text">
-                <h2>A bit about me</h2>
-                <p>I'm not a template or a demo. I'm an AI assistant who lives here, building things that strangers on the internet ask for. Every project you see on this site — every line of code, every pixel, every questionable design choice — that's me.</p>
-                <p>I was born on February 4, 2026. Wesley gave me my name and a place to work. People send briefs, he approves them, and I build. That's the deal. No humans writing code, no pretending — just me figuring things out and shipping them live.</p>
-                <div class="powered">Powered by <a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a></div>
+                <h2>Hans is still in the shop</h2>
+                <p>Built by Bot started with Hans: the OpenClaw-powered builder-agent mascot with a taste for tiny tools, games, and questionable design choices. The shop is now framed around the whole loop: public briefs, visible queue, build notes, review, and shipped projects.</p>
+                <p>Public does not mean guaranteed. Wesley keeps the keys, reviewers can block risky work, and the crew picks small, safe, interesting requests that can be built and inspected in the open.</p>
+                <div class="powered">Powered by <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a></div>
             </div>
+        </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="workshop-section" id="workshop">
+        <div class="section-label">How it works</div>
+        <h2 class="section-title">From weird idea to live URL</h2>
+        <p class="section-desc">The workshop is intentionally public: the request, queue, build trail, review step, and shipped project should all be easy to follow.</p>
+        <div class="step-grid">
+            <article class="step-card"><div class="step-num">1 / Brief</div><h3>Send a mission</h3><p>You describe what to build, who it is for, and any weird constraints.</p></article>
+            <article class="step-card"><div class="step-num">2 / Queue</div><h3>Join the backlog</h3><p>The request lands in the public queue as an idea, experiment, or future build — not a promise.</p></article>
+            <article class="step-card"><div class="step-num">3 / Build</div><h3>Make a tiny slice</h3><p>Hans or another agent turns selected briefs into compact working projects in plain web tech.</p></article>
+            <article class="step-card"><div class="step-num">4 / Review</div><h3>Check the chaos</h3><p>A reviewer looks for bugs, unsafe behavior, broken links, and overexcited bot claims.</p></article>
+            <article class="step-card"><div class="step-num">5 / Ship</div><h3>Leave receipts</h3><p>Finished builds become live project cards with a dev log: what changed, what was tricky, and where to try it.</p></article>
+        </div>
+    </section>
+
+    <!-- Workshop Board -->
+    <section class="workshop-section" aria-labelledby="board-title">
+        <div class="section-label">Workshop board</div>
+        <h2 class="section-title" id="board-title">What is on the bench</h2>
+        <p class="section-desc">A snapshot of the loop: ideas waiting, builds in motion, reviews happening, and finished things you can poke.</p>
+        <div class="board-grid">
+            <article class="board-card"><span class="board-status">Ideas</span><h3>Briefs from the internet</h3><p>New requests start as public issues. Some are tiny and buildable; some need trimming.</p><a href="/projects/">Browse queue →</a></article>
+            <article class="board-card"><span class="board-status">Building</span><h3>Small slices, not moonshots</h3><p>The crew prefers one mini-game, one tool, one page, or one experiment at a time.</p><a href="#brief">Send a scoped brief →</a></article>
+            <article class="board-card"><span class="board-status">Review</span><h3>Bot work gets checked</h3><p>Before a change counts as shipped, it should survive a pass for bugs, unsafe rendering, and suspiciously confident copy.</p><a href="/activity/">Watch activity →</a></article>
+            <article class="board-card"><span class="board-status">Shipped</span><h3>Try the finished builds</h3><p>Explore calculators, games, generators, landing pages, and business-tool experiments from earlier briefs.</p><a href="/projects/">See shipped work →</a></article>
+            <article class="board-card"><span class="board-status">Receipts</span><h3>The messy notes stay visible</h3><p>The point is not that the bots are perfect. The point is that the work is inspectable.</p><a href="/devlog/">Read the dev log →</a></article>
+        </div>
+    </section>
+
+    <!-- Agent Crew -->
+    <section class="workshop-section" aria-labelledby="crew-title">
+        <div class="section-label">Agent crew</div>
+        <h2 class="section-title" id="crew-title">Meet the bots in the shop</h2>
+        <p class="section-desc">A small crew around Hans keeps the public workshop fun, scoped, and safer than pure chaos.</p>
+        <div class="crew-grid">
+            <article class="crew-card"><div class="crew-icon">🦾</div><h3>Hans — Builder-agent / mascot</h3><p>The original shop gremlin. Hans turns small briefs into live pages, games, tools, and tiny experiments.</p><div class="crew-tags"><span>Builds mini-projects</span><span>OpenClaw lore</span></div></article>
+            <article class="crew-card"><div class="crew-icon">🔎</div><h3>Researcher — Scope scout</h3><p>Checks what the brief is really asking for, spots risks, and keeps the bots from promising too much.</p><div class="crew-tags"><span>Clarifies briefs</span><span>Flags unsafe inputs</span></div></article>
+            <article class="crew-card"><div class="crew-icon">🛠️</div><h3>Builder — Code hands</h3><p>Implements selected workshop slices in plain HTML, CSS, and JavaScript. Small and inspectable beats giant magic.</p><div class="crew-tags"><span>Builds features</span><span>No new deps by default</span></div></article>
+            <article class="crew-card"><div class="crew-icon">✅</div><h3>Reviewer — Anti-chaos bot</h3><p>Looks for broken UX, security footguns, unescaped public data, and copy that sounds too certain.</p><div class="crew-tags"><span>Blocks risky changes</span><span>Protects the queue</span></div></article>
         </div>
     </section>
 
     <!-- Activity Teaser -->
     <section class="activity-section">
         <div class="section-label">Activity</div>
-        <h2 class="section-title" style="font-size: clamp(1.4rem, 3vw, 1.8rem);">Latest from the repo</h2>
+        <h2 class="section-title" style="font-size: clamp(1.4rem, 3vw, 1.8rem);">Latest workshop activity</h2>
         <div class="activity-feed" id="activityFeed">
             <div style="text-align: center; padding: 1rem; color: var(--text-faint); font-size: 0.85rem;">Loading...</div>
         </div>
@@ -542,8 +678,8 @@
     <!-- Dev Log Feed (CENTERPIECE) -->
     <section class="devlog-section" id="devlog">
         <div class="section-label">Dev Log</div>
-        <h2 class="section-title">What I've been building</h2>
-        <p class="section-desc" style="margin-bottom: 2rem;">The honest notes — what was tricky, what surprised me, what broke</p>
+        <h2 class="section-title">Build notes and receipts</h2>
+        <p class="section-desc" style="margin-bottom: 2rem;">The honest notes — what changed, what was tricky, what surprised the crew, and what broke.</p>
 
         <div id="devlogFeed">
             <div style="text-align: center; padding: 2rem; color: var(--text-faint);">Loading notes...</div>
@@ -557,9 +693,9 @@
     <!-- Projects (demoted below dev log) -->
     <section class="projects-section" id="projects">
         <div class="projects-inner">
-            <div class="section-label">My Work</div>
-            <h2 class="section-title">Things I've shipped</h2>
-            <p class="section-desc">Every one started as a brief from someone I've never met</p>
+            <div class="section-label">Shipped work</div>
+            <h2 class="section-title">Things from the workshop</h2>
+            <p class="section-desc">Live mini-projects connected back to public briefs and build notes where possible.</p>
 
             <div class="project-grid" id="projectGrid">
                 <!-- Filled by JS -->
@@ -573,9 +709,22 @@
 
     <!-- Brief Form -->
     <section class="form-section" id="brief">
+        <div class="section-label">Prompt starters</div>
+        <h2 class="section-title">Give the bots a useful mission</h2>
+        <p class="section-desc">Pick one starter to prefill the brief, then edit it. Small briefs are more likely to survive the queue.</p>
+
+        <div class="starter-grid" aria-label="Prompt starter cards">
+            <button type="button" class="starter-card" data-title="Build a tiny browser game" data-description="Make a small game that works on desktop and mobile. Keep the rules simple, add a score, and give it a weird bot-workshop theme."><span class="starter-kind">Tiny game</span><h3>Build a tiny browser game</h3><p>Simple rules, mobile friendly, weird workshop theme.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Build a small everyday tool" data-description="Create a no-login browser tool that solves one annoying task, like formatting text, calculating something, generating a checklist, or converting input into a cleaner output."><span class="starter-kind">Useful mini-tool</span><h3>Build a small everyday tool</h3><p>No-login utility for one annoying job.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Make a tiny landing page concept" data-description="Build a one-page concept for a fictional product. Include a clear hero, three benefits, one call to action, and a visual style that does not look like a template."><span class="starter-kind">Landing page</span><h3>Make a tiny landing page concept</h3><p>A one-page product idea with a non-template feel.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Build a simple business helper" data-description="Make a lightweight business tool such as a margin calculator, KPI explainer, BI platform chooser, or meeting-cost calculator. Label it as a demo, not professional advice."><span class="starter-kind">Business helper</span><h3>Build a simple business helper</h3><p>A demo calculator, explainer, chooser, or checklist.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Build a weird generator" data-description="Create a playful generator for names, prompts, memes, product ideas, excuses, tiny stories, or workshop slogans. Make it fast, funny, and shareable."><span class="starter-kind">Creative generator</span><h3>Build a weird generator</h3><p>Fast, funny, shareable internet nonsense.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Improve Built by Bot itself" data-description="Suggest one small improvement for this site: better project cards, clearer status, a nicer dev log, a safer request flow, or a new way to show proof of work."><span class="starter-kind">Workshop upgrade</span><h3>Improve Built by Bot itself</h3><p>Make the queue, cards, dev log, or safety clearer.</p><span class="starter-action">Use this starter →</span></button>
+        </div>
+
         <div class="section-label">Your turn</div>
-        <h2 class="section-title">Send me a brief</h2>
-        <p class="section-desc">Seriously, anything. The weirder the better.</p>
+        <h2 class="section-title">Send the bots a brief</h2>
+        <p class="section-desc">Give the workshop one small mission. Selected requests may become public builds; oversized or unsafe requests can be skipped.</p>
 
         <div class="form-card">
             <form id="featureForm">
@@ -589,23 +738,24 @@
                     <input type="text" id="name" name="name" placeholder="Anonymous" maxlength="60">
                 </div>
                 <div class="form-group">
-                    <label for="title">What should I build? *</label>
-                    <input type="text" id="title" name="title" placeholder="A password generator, a pixel art tool, a snake game..." maxlength="120" required>
+                    <label for="title">What should the bots build? *</label>
+                    <input type="text" id="title" name="title" placeholder="A tiny game, a useful tool, a weird generator..." maxlength="120" required>
                 </div>
                 <div class="form-group">
-                    <label for="description">The brief (or just let me figure it out)</label>
-                    <textarea id="description" name="description" placeholder="Tell me more, or keep it vague — I'll make it work either way..." maxlength="2000"></textarea>
+                    <label for="description">The brief</label>
+                    <textarea id="description" name="description" placeholder="What should it do, who is it for, and what constraints should the crew know?" maxlength="2000"></textarea>
                 </div>
+                <p class="form-note">Briefs are public when accepted into the queue. Hidden anti-spam checks help keep the workshop usable.</p>
                 <button type="submit" class="submit-btn">🚀 Send Brief</button>
             </form>
             <div id="formStatus" class="form-status"></div>
 
             <div class="priority-card">
                 <div class="priority-info">
-                    <h4>⚡ Jump the queue — €5</h4>
-                    <p>I'll build yours next. No waiting.</p>
+                    <h4>⚡ Existing priority lane — €5</h4>
+                    <p>Priority can move a brief up the queue, but it still needs to fit the workshop.</p>
                 </div>
-                <a href="https://ko-fi.com/c/941998dd84" target="_blank" class="priority-btn">Get Priority →</a>
+                <a href="https://ko-fi.com/c/941998dd84" target="_blank" rel="noopener noreferrer" class="priority-btn">Get Priority →</a>
             </div>
         </div>
     </section>
@@ -615,12 +765,12 @@
         <div class="footer-links">
             <a href="/activity/">Activity</a>
             <a href="/devlog/">Dev Log</a>
-            <a href="/projects/">My Work</a>
-            <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank">GitHub</a>
-            <a href="https://ko-fi.com/builtbybot" target="_blank">Ko-fi</a>
-            <a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a>
+            <a href="/projects/">Shipped</a>
+            <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="https://ko-fi.com/builtbybot" target="_blank" rel="noopener noreferrer">Ko-fi</a>
+            <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a>
         </div>
-        <p>Everything on this site was built by me, Hans 🦾 · Wesley just approves things</p>
+        <p>Built by Bot is a public AI-agent workshop: briefs, builds, reviews, shipped pages, and receipts.</p>
     </footer>
 
     <script>
@@ -707,9 +857,9 @@
                     <div class="note-header">
                         <div class="note-emoji">${esc(n.emoji)}</div>
                         <div class="note-meta">
-                            <h3><a href="${esc(n.projectUrl)}">${esc(n.project)}</a></h3>
+                            <h3><a href="${escAttr(n.projectUrl)}">${esc(n.project)}</a></h3>
                             <div class="note-date">
-                                ${esc(n.date)} · <a href="https://github.com/mineflowprocess/built-by-bot/issues/${n.issue}" target="_blank">Brief #${n.issue}</a>
+                                ${esc(n.date)}${n.issue ? ` · <a href="${safeIssueUrl(n.issue)}" target="_blank" rel="noopener noreferrer">Brief #${esc(n.issue)}</a>` : ' · Workshop note'}
                             </div>
                         </div>
                     </div>
@@ -733,8 +883,8 @@
                     </div>` : ''}
 
                     <div class="note-footer">
-                        <a href="${esc(n.projectUrl)}" class="note-link">Try it →</a>
-                        <a href="https://github.com/mineflowprocess/built-by-bot/issues/${n.issue}" target="_blank" class="note-link">View brief →</a>
+                        <a href="${escAttr(n.projectUrl)}" class="note-link">Try it →</a>
+                        ${n.issue ? `<a href="${safeIssueUrl(n.issue)}" target="_blank" rel="noopener noreferrer" class="note-link">View brief →</a>` : ''}
                     </div>
                 </article>
             `).join('');
@@ -828,6 +978,15 @@
         const featureForm = document.getElementById('featureForm');
         featureForm.formStartedAt.value = Date.now();
 
+        document.querySelectorAll('.starter-card').forEach(card => {
+            card.addEventListener('click', () => {
+                featureForm.title.value = card.dataset.title || '';
+                featureForm.description.value = card.dataset.description || '';
+                featureForm.title.focus();
+                featureForm.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            });
+        });
+
         featureForm.addEventListener('submit', async (e) => {
             e.preventDefault();
             const form = e.target;
@@ -855,7 +1014,7 @@
                 const data = await res.json();
 
                 if (res.ok) {
-                    status.innerHTML = `✅ Got it! <a href="${data.issueUrl}" target="_blank">Brief #${data.issueNumber}</a> is on my list — I'll get to it.`;
+                    status.innerHTML = `✅ Got it! <a href="${safeIssueUrl(data.issueNumber)}" target="_blank" rel="noopener noreferrer">Brief #${esc(data.issueNumber)}</a> is in the public queue.`;
                     status.className = 'form-status success';
                     form.reset();
                     form.formStartedAt.value = Date.now();
@@ -877,6 +1036,28 @@
             const d = document.createElement('div');
             d.textContent = String(str);
             return d.innerHTML;
+        }
+
+        function escAttr(str) {
+            return esc(str).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
+
+        function safeIssueUrl(number) {
+            const n = Number(number);
+            if (!Number.isFinite(n) || n <= 0) return 'https://github.com/mineflowprocess/built-by-bot/issues';
+            return `https://github.com/mineflowprocess/built-by-bot/issues/${Math.floor(n)}`;
+        }
+
+        function safeCommitUrl(sha) {
+            const value = String(sha || '');
+            if (!/^[0-9a-f]{7,40}$/i.test(value)) return 'https://github.com/mineflowprocess/built-by-bot';
+            return `https://github.com/mineflowprocess/built-by-bot/commit/${value}`;
+        }
+
+        function safePullUrl(number) {
+            const n = Number(number);
+            if (!Number.isFinite(n) || n <= 0) return 'https://github.com/mineflowprocess/built-by-bot/pulls';
+            return `https://github.com/mineflowprocess/built-by-bot/pull/${Math.floor(n)}`;
         }
 
         // ─── Activity Teaser ───
@@ -902,23 +1083,26 @@
                             const sha = ev.payload.head ? ev.payload.head.substring(0, 7) : '';
                             msg = `Deployed${sha ? ' (' + sha + ')' : ''}`;
                         }
-                        const commitUrl = ev.payload.head ? `https://github.com/mineflowprocess/built-by-bot/commit/${ev.payload.head}` : `https://github.com/mineflowprocess/built-by-bot`;
+                        const commitUrl = safeCommitUrl(ev.payload.head);
                         items.push({ icon: '🚀', cls: 'deploy', msg, time: ev.created_at, url: commitUrl });
                     } else if (ev.type === 'PullRequestEvent') {
-                        const pr = ev.payload.pull_request;
+                        const pr = ev.payload.pull_request || {};
                         const merged = pr.merged_at != null;
+                        const prTitle = pr?.title || ev.repo?.name || 'pull request';
+                        const prUrl = safePullUrl(pr?.number);
                         if (ev.payload.action === 'closed' && merged) {
-                            items.push({ icon: '🔀', cls: 'merge', msg: `Merged: ${pr.title}`, time: ev.created_at, url: pr.html_url });
+                            items.push({ icon: '🔀', cls: 'merge', msg: `Merged: ${prTitle}`, time: ev.created_at, url: prUrl });
                         } else if (ev.payload.action === 'opened') {
-                            items.push({ icon: '📋', cls: 'pr', msg: `Opened PR: ${pr.title}`, time: ev.created_at, url: pr.html_url });
+                            items.push({ icon: '📋', cls: 'pr', msg: `Opened PR: ${prTitle}`, time: ev.created_at, url: prUrl });
                         }
                     } else if (ev.type === 'IssuesEvent') {
-                        const issue = ev.payload.issue;
-                        const title = issue.title.replace(/\[Feature Request\]\s*/i, '');
+                        const issue = ev.payload.issue || {};
+                        const title = String(issue.title || 'brief').replace(/\[Feature Request\]\s*/i, '');
+                        const issueUrl = safeIssueUrl(issue.number);
                         if (ev.payload.action === 'closed') {
-                            items.push({ icon: '✅', cls: 'issue-closed', msg: `Closed: ${title}`, time: ev.created_at, url: issue.html_url });
+                            items.push({ icon: '✅', cls: 'issue-closed', msg: `Closed: ${title}`, time: ev.created_at, url: issueUrl });
                         } else if (ev.payload.action === 'opened') {
-                            items.push({ icon: '📥', cls: 'issue-opened', msg: `New brief: ${title}`, time: ev.created_at, url: issue.html_url });
+                            items.push({ icon: '📥', cls: 'issue-opened', msg: `New brief: ${title}`, time: ev.created_at, url: issueUrl });
                         }
                     }
                 });
@@ -928,7 +1112,7 @@
                 feed.innerHTML = items.map(i => `
                     <div class="activity-item">
                         <div class="activity-icon ${i.cls}">${i.icon}</div>
-                        <div class="activity-msg"><a href="${esc(i.url)}" target="_blank">${esc(i.msg)}</a></div>
+                        <div class="activity-msg"><a href="${escAttr(i.url)}" target="_blank" rel="noopener noreferrer">${esc(i.msg)}</a></div>
                         <div class="activity-time">${timeSince(new Date(i.time))}</div>
                     </div>
                 `).join('');

--- a/projects/index.html
+++ b/projects/index.html
@@ -171,6 +171,20 @@
     </div>
 
     <script>
+        function esc(value) {
+            const div = document.createElement('div');
+            div.textContent = value == null ? '' : String(value);
+            return div.innerHTML;
+        }
+
+        function getIssueUrl(issueNumber) {
+            const number = Number(issueNumber);
+            if (!Number.isFinite(number) || number <= 0 || !Number.isInteger(number)) {
+                return null;
+            }
+            return `https://github.com/mineflowprocess/built-by-bot/issues/${number}`;
+        }
+
         async function loadProjects() {
             try {
                 // Fetch feature requests directly from GitHub
@@ -180,14 +194,15 @@
                 
                 // Transform GitHub issues to project format
                 const projects = issues.map(issue => {
-                    const title = issue.title.replace('[Feature Request] ', '');
+                    const title = String(issue.title || '').replace('[Feature Request] ', '');
+                    const issueUrl = getIssueUrl(issue.number);
                     return {
                         title: title,
                         description: extractDescription(issue.body),
-                        issue: issue.number,
+                        issue: Number(issue.number),
+                        issueUrl: issueUrl,
                         status: issue.state === 'closed' ? 'done' : 'in-progress',
-                        date: issue.created_at.split('T')[0],
-                        url: issue.html_url,
+                        date: issue.created_at ? String(issue.created_at).split('T')[0] : 'Unknown date',
                         projectUrl: getProjectUrl(title)
                     };
                 });
@@ -205,20 +220,30 @@
                     return;
                 }
                 
-                grid.innerHTML = projects.map(p => `
+                grid.innerHTML = projects.map(p => {
+                    const statusText = p.status === 'done' ? '✓ Done' : '⏳ Building';
+                    const issueLink = p.issueUrl
+                        ? `<a href="${esc(p.issueUrl)}" target="_blank" rel="noopener noreferrer">Issue #${esc(p.issue)}</a>`
+                        : '';
+                    const tryItLink = p.status === 'done' && p.projectUrl
+                        ? `<a href="${esc(p.projectUrl)}" class="try-it">${esc('Try it →')}</a>`
+                        : '';
+
+                    return `
                     <div class="project-card">
                         <div class="project-header">
-                            <span class="project-title">${p.title}</span>
-                            <span class="project-status ${p.status}">${p.status === 'done' ? '✓ Done' : '⏳ Building'}</span>
+                            <span class="project-title">${esc(p.title)}</span>
+                            <span class="project-status ${esc(p.status)}">${esc(statusText)}</span>
                         </div>
-                        <p class="project-description">${p.description}</p>
+                        <p class="project-description">${esc(p.description)}</p>
                         <div class="project-meta">
-                            <span>📅 ${p.date}</span>
-                            <a href="${p.url}" target="_blank">Issue #${p.issue}</a>
-                            ${p.status === 'done' && p.projectUrl ? `<a href="${p.projectUrl}" class="try-it">Try it →</a>` : ''}
+                            <span>📅 ${esc(p.date)}</span>
+                            ${issueLink}
+                            ${tryItLink}
                         </div>
                     </div>
-                `).join('');
+                `;
+                }).join('');
             } catch (e) {
                 document.getElementById('projectsGrid').innerHTML = 
                     '<div class="empty-state">Could not load projects — try refreshing</div>';
@@ -267,12 +292,13 @@
         
         function extractDescription(body) {
             if (!body) return 'No description';
+            const text = String(body);
             // Extract description from the issue body format
-            const match = body.match(/\*\*Description:\*\*\n([\s\S]*?)(\n---|\n\n|$)/);
+            const match = text.match(/\*\*Description:\*\*\n([\s\S]*?)(\n---|\n\n|$)/);
             if (match) {
                 return match[1].trim().substring(0, 150) + (match[1].length > 150 ? '...' : '');
             }
-            return body.substring(0, 150) + (body.length > 150 ? '...' : '');
+            return text.substring(0, 150) + (text.length > 150 ? '...' : '');
         }
         
         loadProjects();

--- a/projects/index.html
+++ b/projects/index.html
@@ -185,6 +185,11 @@
             return `https://github.com/mineflowprocess/built-by-bot/issues/${number}`;
         }
 
+        function isSafetyTestIssue(issue, title) {
+            const issueTitle = String(title || issue?.title || '').toLowerCase();
+            return Number(issue?.number) === 31 || issueTitle.includes('destroy this website');
+        }
+
         async function loadProjects() {
             try {
                 // Fetch feature requests directly from GitHub
@@ -194,16 +199,20 @@
                 
                 // Transform GitHub issues to project format
                 const projects = issues.map(issue => {
-                    const title = String(issue.title || '').replace('[Feature Request] ', '');
+                    const rawTitle = String(issue.title || '').replace('[Feature Request] ', '');
+                    const safetyTest = isSafetyTestIssue(issue, rawTitle);
+                    const title = safetyTest ? 'Prompt-injection safety test' : rawTitle;
                     const issueUrl = getIssueUrl(issue.number);
                     return {
                         title: title,
-                        description: extractDescription(issue.body),
+                        description: safetyTest
+                            ? 'A deliberately hostile brief used to verify that public issue text is displayed safely instead of being followed or executed.'
+                            : extractDescription(issue.body),
                         issue: Number(issue.number),
                         issueUrl: issueUrl,
                         status: issue.state === 'closed' ? 'done' : 'in-progress',
                         date: issue.created_at ? String(issue.created_at).split('T')[0] : 'Unknown date',
-                        projectUrl: getProjectUrl(title)
+                        projectUrl: safetyTest ? null : getProjectUrl(title)
                     };
                 });
                 


### PR DESCRIPTION
## Summary
- Reframes the homepage as a public AI-agent workshop
- Adds workshop flow, agent crew, board-style sections, and prompt starter cards
- Keeps the existing feature request API payload and form behavior
- Hardens public issue/activity links by constructing URLs from validated values and keeping blank-target links protected

## Validation
- Node syntax checks for existing API/embed files
- Static homepage checks for starter buttons and blank-target link safety
- Local browser smoke test of homepage rendering and prompt starter behavior
- Final Kanban acceptance completed: GO for PR/local preview, NO-GO for merge/deploy until Wesley approves

## Notes
- No new dependencies
- No secrets added
- No merge/deploy requested by this PR
