### PR TITLE
docs: sharpen 100 days site framing

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,11 +721,11 @@
 
     <!-- Hero -->
     <section class="hero" id="main-content" tabindex="-1">
-        <div class="hero-kicker">PUBLIC PROOF-OF-WORK · BRIEF → QUEUE → BUILD → REVIEW → SHIP</div>
+        <div class="hero-kicker">100 DAYS OF REVIEWED AI BUILDS · ONE SMALL PR AT A TIME</div>
         <h1>Reviewed AI workflows, <span class="gradient">shown in the open.</span></h1>
 
         <p class="hero-subtitle">
-            Built by Bot is an independent proof-of-work lab for small AI and data workflow experiments that leave receipts: public briefs, visible queue, review notes, shipped demos, and the occasional workshop scar.
+            Built by Bot is an independent proof-of-work lab for small AI and data workflow experiments. The 100-days rhythm keeps the promise simple: one scoped improvement, one review trail, one public receipt at a time.
         </p>
 
         <div class="hero-cta">
@@ -757,7 +757,7 @@
             <div class="intro-text">
                 <h2>A serious lab with workshop fingerprints</h2>
                 <p>Built by Bot started as a playful public AI-agent workshop. The new focus is sharper: demonstrate reviewed AI/data workflow experiments in the open, with enough context for a business reader to judge usefulness and enough charm to keep the build loop human.</p>
-                <p>Public does not mean automatic. Wesley keeps the keys, reviewers can block risky work, and the crew picks small, safe, interesting requests that can be built and inspected without pretending a demo is production software.</p>
+                <p>Public does not mean automatic. A human owner keeps the keys, reviewers can block risky work, and the crew picks small, safe, interesting requests that can be built and inspected without pretending a demo is production software.</p>
                 <div class="powered">Powered by <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a></div>
             </div>
         </div>


### PR DESCRIPTION
## Wat is verbeterd
- De hero-kicker zet de site duidelijker neer als een 100-days proof-of-work ritme.
- De hero-copy maakt de dagelijkse belofte concreet: één kleine verbetering, één review trail, één publiek bewijsstuk.
- De intro-copy gebruikt neutrale publieke formulering voor eigenaarschap.

## Waarom dit vandaag waarde toevoegt
- Businessbezoekers zien sneller dat dit geen losse demo-verzameling is, maar een gecontroleerde dagelijkse build/review-cadence.
- De publieke positionering blijft onafhankelijk en review-first.

## Checks
- Git diff geïnspecteerd.
- HTML smoke check uitgevoerd op de nieuwe 100-days teksten en bestaande anchors.
- Werkboom gescand op verboden merk-/persoonsvermeldingen.
- Diff-additions gescand op secret/token/key/password-achtige waarden.

Niet gemerged; wacht op approval.
