### PR TITLE
docs: clarify business use case cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
         }
         .proof-stat strong { display: block; font-size: 1.2rem; letter-spacing: -0.02em; }
         .proof-stat span { color: var(--text-dim); font-size: 0.78rem; }
-        .proof-case-grid { grid-template-columns: repeat(3, 1fr); }
+        .proof-case-grid { grid-template-columns: repeat(4, 1fr); }
         .proof-case, .guidance-card {
             background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.015));
             border: 1px solid var(--border); border-radius: var(--radius); padding: 1.45rem;
@@ -765,12 +765,13 @@
 
     <!-- Proof Cases -->
     <section class="workshop-section" id="proof">
-        <div class="section-label">Proof cases</div>
-        <h2 class="section-title">Business-relevant experiments, not vague AI claims</h2>
-        <p class="section-desc">The best builds are compact enough to inspect and concrete enough to reveal where AI-assisted workflows help, fail, or need human review.</p>
+        <div class="section-label">Business use cases</div>
+        <h2 class="section-title">Concrete experiments, not vague AI claims</h2>
+        <p class="section-desc">The best builds are compact enough to inspect and concrete enough to show where AI-assisted workflows help, fail, or need human review.</p>
         <div class="proof-case-grid">
             <article class="proof-case"><span class="case-label">Decision support</span><h3>Workflow helpers</h3><p>Small calculators, checklists, comparison tools, KPI explainers, and BI decision aids that turn messy choices into clearer next steps.</p></article>
             <article class="proof-case"><span class="case-label">Data handling</span><h3>Readable transformations</h3><p>Experiments that clean, structure, summarize, or validate input in the browser while keeping the assumptions visible.</p></article>
+            <article class="proof-case"><span class="case-label">Internal tools</span><h3>Backoffice helpers</h3><p>Browser-first prototypes for intake, triage, planning, or admin workflows where reviewability matters more than automation hype.</p></article>
             <article class="proof-case"><span class="case-label">Communication</span><h3>Useful interfaces</h3><p>Landing pages, generators, explainers, and interactive demos that test whether an idea can be made understandable quickly.</p></article>
         </div>
     </section>


### PR DESCRIPTION
## Improvement type
Add

## Summary
- Clarifies the proof section as business use cases
- Adds an internal tools/backoffice helper card
- Keeps the change limited to public homepage copy and layout

## Why this helps
- Makes the proof section slightly more business-oriented
- Keeps the change small, although it is an additive improvement and should be reviewed against the new editorial-by-default rule

## Checks
- Checked git diff for whitespace errors
- Scanned repository text for private brand/person terms before publishing

Not merged; awaiting approval.
