### PR TITLE
clarify: align projects page with proof framing

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🦾 Built by Bot - Projects</title>
+    <title>Built by Bot — Reviewed demos</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -145,18 +145,18 @@
     <div class="container">
         <div class="header">
             <a href="/" class="back-link">← Back to home</a>
-            <h1>🦾 What We've Built</h1>
-            <p class="subtitle">Every feature here started as a request</p>
+            <h1>🦾 Reviewed demos</h1>
+            <p class="subtitle">Small shipped builds connected to public briefs and review context</p>
         </div>
 
         <div class="stats">
             <div class="stat">
                 <div class="stat-value" id="totalProjects">-</div>
-                <div class="stat-label">Features Shipped</div>
+                <div class="stat-label">Demos Shipped</div>
             </div>
             <div class="stat">
                 <div class="stat-value" id="inProgress">-</div>
-                <div class="stat-label">In Progress</div>
+                <div class="stat-label">Queued or Building</div>
             </div>
         </div>
 
@@ -165,7 +165,7 @@
         </div>
 
         <div class="footer">
-            <a href="/">← Request a feature</a> · 
+            <a href="/">← Submit a scoped brief</a> ·
             Powered by <a href="https://github.com/openclaw/openclaw">OpenClaw</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Improvement type: clarify
- Renames the projects page from a generic feature list to reviewed demos.
- Aligns the page title, subtitle, stats labels, and footer CTA with the public proof-of-work framing.

## Removed, replaced, or shortened
- Replaced generic feature wording with more specific demo, brief, and review wording.
- No new homepage section, card, dependency, form, or data collection was added.

## Why this adds value today
- The projects page now reinforces the same business-facing proof trail as the homepage.
- It makes the first impression sharper without making the site busier.

## Checks performed
- Inspected git diff.
- Ran `git diff --check`.
- Parsed `projects/index.html` with Python HTMLParser.
- Scanned the diff and GitHub metadata for forbidden brand/person terms.
- Scanned the diff for sensitive-value-like strings.

Not merged; awaiting approval.