### PR TITLE
Tighten Built by Bot homepage flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Built by Bot — Public proof-of-work for reviewed AI workflows</title>
-    <meta name="description" content="Built by Bot is a public proof-of-work lab for reviewed AI and data workflow experiments: briefs, queue, build notes, review steps, and shipped demos.">
+    <title>Built by Bot — Small AI workflow demos, reviewed in public</title>
+    <meta name="description" content="Submit a focused, non-sensitive workflow idea. Selected Built by Bot briefs become public AI-assisted demos with review notes, activity links, and live results.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
@@ -286,7 +286,7 @@
         .step-grid, .board-grid, .crew-grid, .starter-grid, .proof-strip, .proof-case-grid, .guidance-grid {
             display: grid; gap: 1rem;
         }
-        .proof-strip { grid-template-columns: repeat(4, 1fr); margin-top: 2.25rem; width: min(980px, 100%); }
+        .proof-strip { grid-template-columns: repeat(3, 1fr); margin-top: 2.25rem; width: min(980px, 100%); }
         .proof-stat {
             padding: 1rem; border: 1px solid var(--border); border-radius: 14px;
             background: rgba(255,255,255,0.035); text-align: left;
@@ -308,7 +308,7 @@
         .guidance-grid { grid-template-columns: repeat(2, 1fr); }
         .guidance-card ul { margin-top: 0.9rem; padding-left: 1.1rem; color: var(--text-dim); font-size: 0.86rem; }
         .guidance-card li { margin-bottom: 0.45rem; }
-        .step-grid { grid-template-columns: repeat(5, 1fr); }
+        .step-grid { grid-template-columns: repeat(4, 1fr); }
         .board-grid { grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
         .crew-grid { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
         .starter-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin-bottom: 2rem; }
@@ -690,10 +690,10 @@
             <span class="nav-mark">BB</span> Built by Bot
         </a>
         <div class="nav-links">
+            <a href="/projects/">Demos</a>
+            <a href="#proof">How it works</a>
             <a href="/activity/">Activity</a>
-            <a href="#proof">Proof</a>
-            <a href="#workshop">Workshop</a>
-            <a href="#brief">Submit Brief</a>
+            <a href="#brief">Submit an idea</a>
             <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer" class="gh-btn">
                 GitHub
             </a>
@@ -720,30 +720,30 @@
     <!-- Hero -->
     <section class="hero" id="main-content" tabindex="-1">
         <div class="hero-kicker">100 DAYS OF REVIEWED AI BUILDS · ONE SMALL PR AT A TIME</div>
-        <h1>Reviewed AI workflows, <span class="gradient">shown in the open.</span></h1>
+        <h1>Small AI workflow demos, <span class="gradient">reviewed in public.</span></h1>
 
         <p class="hero-subtitle">
-            Built by Bot is an independent lab for small AI and data workflow experiments. Each build keeps the promise simple: a scoped brief, a review pass, and a public receipt.
+            Submit a focused, non-sensitive workflow idea. Selected briefs become public demos with review notes, activity links, and a live result you can inspect.
         </p>
 
         <div class="hero-cta">
-            <a href="#brief" class="btn btn-primary">Submit a scoped brief</a>
-            <a href="#proof" class="btn btn-secondary">Review the proof</a>
+            <a href="#brief" class="btn btn-primary">Submit a small workflow idea</a>
+            <a href="/projects/" class="btn btn-secondary">See reviewed builds</a>
         </div>
-        <p class="hero-proof">Not a black-box agency pitch. Not a benchmark theater. A public build loop for useful, reviewable slices of AI-assisted work.</p>
-        <aside class="latest-receipt" aria-label="Latest public receipt">
+        <p class="hero-proof">Not a black-box agency pitch. Not benchmark theater. A public build loop for useful, reviewable slices of AI-assisted work.</p>
+        <aside class="latest-receipt" aria-label="Latest public build activity">
             <div class="receipt-icon" aria-hidden="true">↳</div>
             <div>
-                <span class="receipt-label">Latest receipt</span>
+                <span class="receipt-label">Latest public build activity</span>
                 <span class="receipt-title" id="receiptTitle">Reviewed homepage rebrand</span>
-                <span class="receipt-meta" id="receiptMeta">Public queue · review notes · live deploy trail</span>
+                <span class="receipt-meta" id="receiptMeta">Public queue · review notes · live deploy links</span>
             </div>
-            <a class="receipt-link" id="receiptLink" href="/activity/">View activity →</a>
+            <a class="receipt-link" id="receiptLink" href="/activity/">Inspect build record →</a>
         </aside>
         <div class="proof-strip" aria-label="Proof points">
-            <div class="proof-stat"><strong>Public queue</strong><span>Accepted briefs become inspectable GitHub issues.</span></div>
-            <div class="proof-stat"><strong>Reviewed changes</strong><span>Bot work is checked before it counts as shipped.</span></div>
-            <div class="proof-stat"><strong>Live demos</strong><span>Small tools and workflow slices are deployed, not just described.</span></div>
+            <div class="proof-stat"><strong>Submit publicly</strong><span>Accepted requests become inspectable GitHub issues.</span></div>
+            <div class="proof-stat"><strong>Reviewed before shipping</strong><span>Builds are checked for bugs, unsafe behavior, exposed data, and overconfident claims.</span></div>
+            <div class="proof-stat"><strong>Try the result</strong><span>Small tools and workflow slices are deployed, not just described.</span></div>
         </div>
     </section>
 
@@ -752,8 +752,8 @@
         <div class="intro-card">
             <div class="intro-avatar">🦾</div>
             <div class="intro-text">
-                <h2>A serious lab with workshop fingerprints</h2>
-                <p>Built by Bot started as a playful public AI-agent workshop. The sharper focus now is useful, reviewable workflow demos: small enough to inspect, practical enough for a business reader, and still human enough to feel like a workshop.</p>
+                <h2>Small demos, built and reviewed in public</h2>
+                <p>Built by Bot is a playful public AI-agent workshop with a practical filter: every selected idea should be small enough to inspect, useful enough for a business reader, and reviewed before it counts as shipped.</p>
                 <div class="powered">Powered by <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a></div>
             </div>
         </div>
@@ -763,19 +763,19 @@
     <section class="workshop-section" id="proof">
         <div class="section-label">Proof in one loop</div>
         <h2 class="section-title">How the lab works</h2>
-        <p class="section-desc">One compact path replaces the hype: start with a small workflow problem, build a demo, review the claims, and leave receipts a visitor can inspect.</p>
+        <p class="section-desc">One compact path replaces the hype: start with a small workflow problem, build a demo, review the claims, and publish links a visitor can inspect.</p>
         <div class="step-grid" id="workshop">
-            <article class="step-card"><div class="step-num">1 / Brief</div><h3>Start small</h3><p>Good requests focus on one user, one workflow, sample non-sensitive input, and a clear success signal.</p></article>
+            <article class="step-card"><div class="step-num">1 / Submit</div><h3>Start small</h3><p>Good requests focus on one user, one workflow, sample non-sensitive input, and a clear success signal.</p></article>
             <article class="step-card"><div class="step-num">2 / Build</div><h3>Make it work</h3><p>Selected briefs become plain web demos: helpers, calculators, data cleanup experiments, explainers, or tiny tools.</p></article>
             <article class="step-card"><div class="step-num">3 / Review</div><h3>Check the claims</h3><p>Before a build counts as shipped, it gets checked for bugs, unsafe behavior, exposed data, and overconfident copy.</p></article>
-            <article class="step-card"><div class="step-num">4 / Receipt</div><h3>Leave the trail</h3><p>The public queue, activity feed, dev notes, and live demos show what changed and where to inspect it.</p></article>
+            <article class="step-card"><div class="step-num">4 / Publish</div><h3>Publish the trail</h3><p>The public queue, activity feed, dev notes, and live demos show what changed and where to inspect it.</p></article>
         </div>
     </section>
 
     <!-- Submission Guidance -->
     <section class="workshop-section" aria-labelledby="guidance-title">
         <div class="section-label">Submission guidance</div>
-        <h2 class="section-title" id="guidance-title">What to submit — and what not to</h2>
+        <h2 class="section-title" id="guidance-title">What makes a good brief?</h2>
         <p class="section-desc">Useful proof starts with a small, reviewable scope. Keep it safe, specific, and demo-sized.</p>
         <div class="guidance-grid">
             <article class="guidance-card"><span class="case-label">Good fits</span><h3>Small, inspectable workflow experiments</h3><p>Submit ideas that can become a standalone demo and teach something about AI-assisted building.</p><ul><li>Decision helpers, calculators, checklists, and explainers</li><li>Browser-only data cleanup or formatting experiments</li><li>Landing page concepts, generators, and tiny tools</li><li>Clear constraints, sample non-sensitive input, and success criteria</li></ul></article>
@@ -787,7 +787,7 @@
     <section class="form-section" id="brief">
         <div class="section-label">Your turn</div>
         <h2 class="section-title">Submit a public brief</h2>
-        <p class="section-desc">Give the workshop one small mission. Selected requests may become public builds; oversized, sensitive, or unsafe requests can be skipped.</p>
+        <p class="section-desc">Give the workshop one small mission. Your brief enters a public queue; selected requests may become live demos with review notes. Oversized, sensitive, or unsafe requests can be skipped.</p>
 
         <div class="starter-grid starter-grid-compact" aria-label="Prompt starter cards">
             <button type="button" class="starter-card" data-title="Build a lightweight workflow helper" data-description="Create a no-login browser tool that helps with one small workflow, such as formatting input, calculating a tradeoff, generating a checklist, or turning messy notes into a clearer output. Use only non-sensitive sample data."><span class="starter-kind">Workflow helper</span><h3>Build a workflow helper</h3><p>No-login utility for one narrow job.</p><span class="starter-action">Use this starter →</span></button>
@@ -807,24 +807,24 @@
                     <input type="text" id="name" name="name" placeholder="Anonymous" maxlength="60">
                 </div>
                 <div class="form-group">
-                    <label for="title">What should be built? *</label>
-                    <input type="text" id="title" name="title" placeholder="A workflow helper, data experiment, decision tool..." maxlength="120" required>
+                    <label for="title">Short title *</label>
+                    <input type="text" id="title" name="title" placeholder="Example: stock planning calculator for small cafes" maxlength="120" required>
                 </div>
                 <div class="form-group">
-                    <label for="description">The brief</label>
-                    <textarea id="description" name="description" placeholder="What should it do, who is it for, what sample non-sensitive data can be used, and what constraints should the crew know?" maxlength="2000"></textarea>
+                    <label for="description">Brief details</label>
+                    <textarea id="description" name="description" placeholder="Include: who it is for, what problem it solves, what sample non-sensitive data can be used, and what a successful demo should show." maxlength="2000"></textarea>
                 </div>
-                <p class="form-note">Do not include secrets, customer data, private documents, credentials, or anything regulated. Briefs are public when accepted into the queue.</p>
-                <button type="submit" class="submit-btn">Submit Brief</button>
+                <p class="form-note">Accepted briefs are public. Do not include secrets, customer data, private documents, credentials, or anything regulated. If you want a reply, include a public contact method in the brief.</p>
+                <button type="submit" class="submit-btn">Submit public brief</button>
             </form>
             <div id="formStatus" class="form-status"></div>
 
             <div class="priority-card">
                 <div class="priority-info">
-                    <h4>Existing priority lane — €5</h4>
-                    <p>Priority can move a brief up the queue, but it still needs to fit the workshop.</p>
+                    <h4>Optional priority boost — €5</h4>
+                    <p>First submit your brief. Then optionally move it higher in the queue. Payment does not guarantee selection.</p>
                 </div>
-                <a href="https://ko-fi.com/c/941998dd84" target="_blank" rel="noopener noreferrer" class="priority-btn">Get Priority →</a>
+                <a href="https://ko-fi.com/c/941998dd84" target="_blank" rel="noopener noreferrer" class="priority-btn">Add priority →</a>
             </div>
         </div>
     </section>
@@ -883,7 +883,7 @@
             <a href="https://ko-fi.com/builtbybot" target="_blank" rel="noopener noreferrer">Ko-fi</a>
             <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a>
         </div>
-        <p>Built by Bot is public proof-of-work for reviewed AI and data workflow experiments: briefs, builds, reviews, shipped pages, and receipts.</p>
+        <p>Built by Bot turns selected, non-sensitive workflow ideas into public AI-assisted demos with review notes, shipped pages, and inspectable build records.</p>
     </footer>
 
     <script>
@@ -909,7 +909,7 @@
                         const title = current.title.replace(/\[Feature Request\]\s*/i, '');
                         document.getElementById('statusBuilding').textContent = '#' + current.number + ' ' + title;
                     } else {
-                        document.getElementById('statusBuilding').textContent = 'nothing queued — submit a brief';
+                        document.getElementById('statusBuilding').textContent = 'open queue — submit a small idea';
                     }
                 }
 
@@ -1134,7 +1134,7 @@
                 status.className = 'form-status error';
             } finally {
                 btn.disabled = false;
-                btn.textContent = 'Submit Brief';
+                btn.textContent = 'Submit public brief';
             }
         });
 
@@ -1188,7 +1188,7 @@
             title.textContent = item.msg;
             meta.textContent = `${timeSince(new Date(item.time))} · pulled from the public GitHub activity trail`;
             link.href = item.url || '/activity/';
-            link.textContent = 'Inspect receipt →';
+            link.textContent = 'Inspect build record →';
         }
 
         // ─── Activity Teaser ───

--- a/index.html
+++ b/index.html
@@ -723,7 +723,7 @@
         <h1>Reviewed AI workflows, <span class="gradient">shown in the open.</span></h1>
 
         <p class="hero-subtitle">
-            Built by Bot is an independent proof-of-work lab for small AI and data workflow experiments. The 100-days rhythm keeps the promise simple: one scoped improvement, one review trail, one public receipt at a time.
+            Built by Bot is an independent lab for small AI and data workflow experiments. Each build keeps the promise simple: a scoped brief, a review pass, and a public receipt.
         </p>
 
         <div class="hero-cta">
@@ -744,7 +744,6 @@
             <div class="proof-stat"><strong>Public queue</strong><span>Accepted briefs become inspectable GitHub issues.</span></div>
             <div class="proof-stat"><strong>Reviewed changes</strong><span>Bot work is checked before it counts as shipped.</span></div>
             <div class="proof-stat"><strong>Live demos</strong><span>Small tools and workflow slices are deployed, not just described.</span></div>
-            <div class="proof-stat"><strong>Build notes</strong><span>What worked, what broke, and what was learned stays visible.</span></div>
         </div>
     </section>
 
@@ -754,51 +753,22 @@
             <div class="intro-avatar">🦾</div>
             <div class="intro-text">
                 <h2>A serious lab with workshop fingerprints</h2>
-                <p>Built by Bot started as a playful public AI-agent workshop. The new focus is sharper: demonstrate reviewed AI/data workflow experiments in the open, with enough context for a business reader to judge usefulness and enough charm to keep the build loop human.</p>
-                <p>Public does not mean automatic. A human owner keeps the keys, reviewers can block risky work, and the crew picks small, safe, interesting requests that can be built and inspected without pretending a demo is production software.</p>
+                <p>Built by Bot started as a playful public AI-agent workshop. The sharper focus now is useful, reviewable workflow demos: small enough to inspect, practical enough for a business reader, and still human enough to feel like a workshop.</p>
                 <div class="powered">Powered by <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener noreferrer">OpenClaw</a></div>
             </div>
         </div>
     </section>
 
-    <!-- Proof Cases -->
+    <!-- How the lab works -->
     <section class="workshop-section" id="proof">
-        <div class="section-label">Business use cases</div>
-        <h2 class="section-title">Concrete experiments, not vague AI claims</h2>
-        <p class="section-desc">The best builds are compact enough to inspect and concrete enough to show where AI-assisted workflows help, fail, or need human review.</p>
-        <div class="proof-case-grid">
-            <article class="proof-case"><span class="case-label">Decision support</span><h3>Workflow helpers</h3><p>Small calculators, checklists, comparison tools, KPI explainers, and BI decision aids that turn messy choices into clearer next steps.</p></article>
-            <article class="proof-case"><span class="case-label">Data handling</span><h3>Readable transformations</h3><p>Experiments that clean, structure, summarize, or validate input in the browser while keeping the assumptions visible.</p></article>
-            <article class="proof-case"><span class="case-label">Internal tools</span><h3>Backoffice helpers</h3><p>Browser-first prototypes for intake, triage, planning, or admin workflows where reviewability matters more than automation hype.</p></article>
-            <article class="proof-case"><span class="case-label">Communication</span><h3>Useful interfaces</h3><p>Landing pages, generators, explainers, and interactive demos that test whether an idea can be made understandable quickly.</p></article>
-        </div>
-    </section>
-
-    <!-- How it works -->
-    <section class="workshop-section" id="workshop">
-        <div class="section-label">Build loop</div>
-        <h2 class="section-title">From scoped question to reviewed demo</h2>
-        <p class="section-desc">The loop is intentionally public: the request, queue, build trail, review step, and shipped result should all be easy to follow.</p>
-        <div class="step-grid">
-            <article class="step-card"><div class="step-num">1 / Brief</div><h3>Define the slice</h3><p>You describe the workflow, intended user, success signal, and constraints.</p></article>
-            <article class="step-card"><div class="step-num">2 / Queue</div><h3>Join the backlog</h3><p>The request lands in the public queue as an idea, experiment, or future build — not a promise.</p></article>
-            <article class="step-card"><div class="step-num">3 / Build</div><h3>Make a working demo</h3><p>Selected briefs become compact projects in plain web tech, with the bot-workshop process visible.</p></article>
-            <article class="step-card"><div class="step-num">4 / Review</div><h3>Check the claims</h3><p>A reviewer looks for bugs, unsafe behavior, broken links, exposed data, and overconfident copy.</p></article>
-            <article class="step-card"><div class="step-num">5 / Ship</div><h3>Leave receipts</h3><p>Finished builds get live project cards with notes on what changed, what was tricky, and where to try it.</p></article>
-        </div>
-    </section>
-
-    <!-- Workshop Board -->
-    <section class="workshop-section" aria-labelledby="board-title">
-        <div class="section-label">Operating model</div>
-        <h2 class="section-title" id="board-title">What the public trail proves</h2>
-        <p class="section-desc">A snapshot of the evidence layer: ideas waiting, builds in motion, reviews happening, and finished things you can inspect.</p>
-        <div class="board-grid">
-            <article class="board-card"><span class="board-status">Ideas</span><h3>Public starting point</h3><p>New requests start as public issues. Some are buildable; some need trimming; some are declined.</p><a href="/projects/">Browse queue →</a></article>
-            <article class="board-card"><span class="board-status">Building</span><h3>Small slices, not platforms</h3><p>The crew prefers one workflow, one tool, one page, or one experiment at a time.</p><a href="#brief">Submit a scoped brief →</a></article>
-            <article class="board-card"><span class="board-status">Review</span><h3>Bot work gets checked</h3><p>Before a change counts as shipped, it should survive a pass for bugs, unsafe rendering, data exposure, and unsupported claims.</p><a href="/activity/">Watch activity →</a></article>
-            <article class="board-card"><span class="board-status">Shipped</span><h3>Try the finished builds</h3><p>Explore calculators, games, generators, landing pages, and business-tool experiments from earlier briefs.</p><a href="/projects/">See shipped work →</a></article>
-            <article class="board-card"><span class="board-status">Receipts</span><h3>The messy notes stay visible</h3><p>The point is not that the bots are perfect. The point is that the work is inspectable.</p><a href="/devlog/">Read the dev log →</a></article>
+        <div class="section-label">Proof in one loop</div>
+        <h2 class="section-title">How the lab works</h2>
+        <p class="section-desc">One compact path replaces the hype: start with a small workflow problem, build a demo, review the claims, and leave receipts a visitor can inspect.</p>
+        <div class="step-grid" id="workshop">
+            <article class="step-card"><div class="step-num">1 / Brief</div><h3>Start small</h3><p>Good requests focus on one user, one workflow, sample non-sensitive input, and a clear success signal.</p></article>
+            <article class="step-card"><div class="step-num">2 / Build</div><h3>Make it work</h3><p>Selected briefs become plain web demos: helpers, calculators, data cleanup experiments, explainers, or tiny tools.</p></article>
+            <article class="step-card"><div class="step-num">3 / Review</div><h3>Check the claims</h3><p>Before a build counts as shipped, it gets checked for bugs, unsafe behavior, exposed data, and overconfident copy.</p></article>
+            <article class="step-card"><div class="step-num">4 / Receipt</div><h3>Leave the trail</h3><p>The public queue, activity feed, dev notes, and live demos show what changed and where to inspect it.</p></article>
         </div>
     </section>
 
@@ -806,75 +776,24 @@
     <section class="workshop-section" aria-labelledby="guidance-title">
         <div class="section-label">Submission guidance</div>
         <h2 class="section-title" id="guidance-title">What to submit — and what not to</h2>
-        <p class="section-desc">Useful proof-of-work starts with a small, reviewable scope. The workshop charm stays; the safety bar goes up.</p>
+        <p class="section-desc">Useful proof starts with a small, reviewable scope. Keep it safe, specific, and demo-sized.</p>
         <div class="guidance-grid">
-            <article class="guidance-card"><span class="case-label">Good fits</span><h3>Small, inspectable workflow experiments</h3><p>Submit ideas that can become a standalone demo and teach something about AI-assisted building.</p><ul><li>Decision helpers, calculators, checklists, explainers</li><li>Browser-only data cleanup or formatting experiments</li><li>Landing page concepts, generators, and tiny tools</li><li>Clear constraints, sample non-sensitive input, and success criteria</li></ul></article>
-            <article class="guidance-card"><span class="case-label">Not accepted</span><h3>Anything risky, private, or production-critical</h3><p>Do not submit material that should stay confidential or work that needs regulated professional judgement.</p><ul><li>No passwords, secrets, customer data, health records, or private documents</li><li>No requests to scrape, impersonate, spam, exploit, or bypass safeguards</li><li>No mission-critical automation or claims of guaranteed business outcomes</li><li>No giant platforms disguised as “one quick build”</li></ul></article>
-        </div>
-    </section>
-
-    <!-- Activity Teaser -->
-    <section class="activity-section">
-        <div class="section-label">Activity</div>
-        <h2 class="section-title" style="font-size: clamp(1.4rem, 3vw, 1.8rem);">Latest public activity</h2>
-        <div class="activity-feed" id="activityFeed">
-            <div style="text-align: center; padding: 1rem; color: var(--text-faint); font-size: 0.85rem;">Loading...</div>
-        </div>
-        <div class="see-all" style="margin-top: 1rem; margin-bottom: 0;">
-            <a href="/activity/" class="btn btn-secondary" style="font-size: 0.85rem; padding: 0.6rem 1.5rem;">View all activity →</a>
-        </div>
-    </section>
-
-    <!-- Dev Log Feed (CENTERPIECE) -->
-    <section class="devlog-section" id="devlog">
-        <div class="section-label">Dev Log</div>
-        <h2 class="section-title">Build notes and review receipts</h2>
-        <p class="section-desc" style="margin-bottom: 2rem;">The honest notes — what changed, what was tricky, what surprised the crew, and what still needs skepticism.</p>
-
-        <div id="devlogFeed">
-            <div style="text-align: center; padding: 2rem; color: var(--text-faint);">Loading notes...</div>
-        </div>
-
-        <div class="see-all">
-            <a href="/devlog/" class="btn btn-secondary">Read the full dev log →</a>
-        </div>
-    </section>
-
-    <!-- Projects (demoted below dev log) -->
-    <section class="projects-section" id="projects">
-        <div class="projects-inner">
-            <div class="section-label">Shipped work</div>
-            <h2 class="section-title">Reviewed demos and workshop artifacts</h2>
-            <p class="section-desc">Live mini-projects connected back to public briefs, build notes, and review context where possible.</p>
-
-            <div class="project-grid" id="projectGrid">
-                <!-- Filled by JS -->
-            </div>
-
-            <div class="see-all">
-                <a href="/projects/" class="btn btn-secondary">View all projects →</a>
-            </div>
+            <article class="guidance-card"><span class="case-label">Good fits</span><h3>Small, inspectable workflow experiments</h3><p>Submit ideas that can become a standalone demo and teach something about AI-assisted building.</p><ul><li>Decision helpers, calculators, checklists, and explainers</li><li>Browser-only data cleanup or formatting experiments</li><li>Landing page concepts, generators, and tiny tools</li><li>Clear constraints, sample non-sensitive input, and success criteria</li></ul></article>
+            <article class="guidance-card"><span class="case-label">Not accepted</span><h3>Anything risky, private, or production-critical</h3><p>Do not submit material that should stay confidential or work that needs regulated professional judgement.</p><ul><li>No passwords, secrets, customer data, health records, or private documents</li><li>No scraping, impersonation, spam, exploits, or bypass requests</li><li>No mission-critical automation or guaranteed business outcomes</li><li>No giant platforms disguised as “one quick build”</li></ul></article>
         </div>
     </section>
 
     <!-- Brief Form -->
     <section class="form-section" id="brief">
-        <div class="section-label">Prompt starters</div>
-        <h2 class="section-title">Give the lab a useful mission</h2>
-        <p class="section-desc">Pick one starter to prefill the brief, then edit it. Small, non-sensitive briefs are more likely to survive the queue.</p>
-
-        <div class="starter-grid" aria-label="Prompt starter cards">
-            <button type="button" class="starter-card" data-title="Build a lightweight workflow helper" data-description="Create a no-login browser tool that helps with one small workflow, such as formatting input, calculating a tradeoff, generating a checklist, or turning messy notes into a clearer output. Use only non-sensitive sample data."><span class="starter-kind">Workflow helper</span><h3>Build a lightweight workflow helper</h3><p>No-login utility for one narrow job.</p><span class="starter-action">Use this starter →</span></button>
-            <button type="button" class="starter-card" data-title="Prototype a data cleanup experiment" data-description="Build a browser-only demo that cleans, classifies, validates, or summarizes sample data. Show assumptions clearly and do not require private or sensitive information."><span class="starter-kind">Data experiment</span><h3>Prototype a data cleanup experiment</h3><p>Readable transformations with visible assumptions.</p><span class="starter-action">Use this starter →</span></button>
-            <button type="button" class="starter-card" data-title="Make a focused landing page concept" data-description="Build a one-page concept for a fictional or public product. Include a clear hero, three proof points, one call to action, and a visual style that does not look like a template."><span class="starter-kind">Landing page</span><h3>Make a focused landing page concept</h3><p>A one-page product idea with proof framing.</p><span class="starter-action">Use this starter →</span></button>
-            <button type="button" class="starter-card" data-title="Build a simple business decision helper" data-description="Make a lightweight business tool such as a margin calculator, KPI explainer, BI platform chooser, or meeting-cost calculator. Label it as a demo, not professional advice."><span class="starter-kind">Decision helper</span><h3>Build a simple business decision helper</h3><p>A demo calculator, explainer, chooser, or checklist.</p><span class="starter-action">Use this starter →</span></button>
-            <button type="button" class="starter-card" data-title="Build a tiny browser game" data-description="Make a small game that works on desktop and mobile. Keep the rules simple, add a score, and give it a subtle workshop theme without distracting from usability."><span class="starter-kind">Workshop charm</span><h3>Build a tiny browser game</h3><p>Simple rules, mobile friendly, still a little odd.</p><span class="starter-action">Use this starter →</span></button>
-            <button type="button" class="starter-card" data-title="Improve Built by Bot itself" data-description="Suggest one small improvement for this site: better project cards, clearer status, a stronger proof trail, a safer request flow, or a more useful dev log."><span class="starter-kind">Site upgrade</span><h3>Improve Built by Bot itself</h3><p>Make the queue, cards, dev log, or safety clearer.</p><span class="starter-action">Use this starter →</span></button>
-        </div>
-
         <div class="section-label">Your turn</div>
         <h2 class="section-title">Submit a public brief</h2>
         <p class="section-desc">Give the workshop one small mission. Selected requests may become public builds; oversized, sensitive, or unsafe requests can be skipped.</p>
+
+        <div class="starter-grid starter-grid-compact" aria-label="Prompt starter cards">
+            <button type="button" class="starter-card" data-title="Build a lightweight workflow helper" data-description="Create a no-login browser tool that helps with one small workflow, such as formatting input, calculating a tradeoff, generating a checklist, or turning messy notes into a clearer output. Use only non-sensitive sample data."><span class="starter-kind">Workflow helper</span><h3>Build a workflow helper</h3><p>No-login utility for one narrow job.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Prototype a data cleanup experiment" data-description="Build a browser-only demo that cleans, classifies, validates, or summarizes sample data. Show assumptions clearly and do not require private or sensitive information."><span class="starter-kind">Data experiment</span><h3>Prototype data cleanup</h3><p>Readable transformations with visible assumptions.</p><span class="starter-action">Use this starter →</span></button>
+            <button type="button" class="starter-card" data-title="Build a simple business decision helper" data-description="Make a lightweight business tool such as a margin calculator, KPI explainer, BI platform chooser, or meeting-cost calculator. Label it as a demo, not professional advice."><span class="starter-kind">Decision helper</span><h3>Build a decision helper</h3><p>A demo calculator, explainer, chooser, or checklist.</p><span class="starter-action">Use this starter →</span></button>
+        </div>
 
         <div class="form-card">
             <form id="featureForm">
@@ -906,6 +825,50 @@
                     <p>Priority can move a brief up the queue, but it still needs to fit the workshop.</p>
                 </div>
                 <a href="https://ko-fi.com/c/941998dd84" target="_blank" rel="noopener noreferrer" class="priority-btn">Get Priority →</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Activity Teaser -->
+    <section class="activity-section">
+        <div class="section-label">Activity</div>
+        <h2 class="section-title" style="font-size: clamp(1.4rem, 3vw, 1.8rem);">Latest public activity</h2>
+        <div class="activity-feed" id="activityFeed">
+            <div style="text-align: center; padding: 1rem; color: var(--text-faint); font-size: 0.85rem;">Loading...</div>
+        </div>
+        <div class="see-all" style="margin-top: 1rem; margin-bottom: 0;">
+            <a href="/activity/" class="btn btn-secondary" style="font-size: 0.85rem; padding: 0.6rem 1.5rem;">View all activity →</a>
+        </div>
+    </section>
+
+    <!-- Dev Log Feed -->
+    <section class="devlog-section" id="devlog">
+        <div class="section-label">Dev Log</div>
+        <h2 class="section-title">Recent build notes</h2>
+        <p class="section-desc" style="margin-bottom: 2rem;">A short preview of what changed, what was tricky, and where to inspect the full note.</p>
+
+        <div id="devlogFeed">
+            <div style="text-align: center; padding: 2rem; color: var(--text-faint);">Loading notes...</div>
+        </div>
+
+        <div class="see-all">
+            <a href="/devlog/" class="btn btn-secondary">Read the full dev log →</a>
+        </div>
+    </section>
+
+    <!-- Projects -->
+    <section class="projects-section" id="projects">
+        <div class="projects-inner">
+            <div class="section-label">Shipped work</div>
+            <h2 class="section-title">Featured demos</h2>
+            <p class="section-desc">A small preview of live mini-projects connected back to public briefs and build notes where possible.</p>
+
+            <div class="project-grid" id="projectGrid">
+                <!-- Filled by JS -->
+            </div>
+
+            <div class="see-all">
+                <a href="/projects/" class="btn btn-secondary">View all projects →</a>
             </div>
         </div>
     </section>
@@ -981,8 +944,8 @@
         async function loadDevLog() {
             const feed = document.getElementById('devlogFeed');
             const slugs = [
-                'api-hardening', 'bi-strategy', 'pub-game', 'meme', 'furniture',
-                'dammies-beer', 'robot-game', 'qr-code', 'typing-test', 'calculator'
+                'bi-strategy', 'pub-game', 'meme', 'furniture', 'dammies-beer',
+                'robot-game', 'qr-code', 'typing-test', 'calculator'
             ];
             const notes = [];
 
@@ -998,9 +961,9 @@
                 return;
             }
 
-            // Sort newest first, show 5
+            // Sort newest first, show a compact homepage preview
             notes.sort((a, b) => b.date.localeCompare(a.date));
-            const show = notes.slice(0, 5);
+            const show = notes.slice(0, 3);
 
             feed.innerHTML = show.map(n => `
                 <article class="note-card">
@@ -1015,22 +978,14 @@
                     </div>
 
                     <div class="note-section">
-                        <div class="note-label label-built">What I Built</div>
-                        <div class="note-text">${esc(n.what_i_built)}</div>
+                        <div class="note-label label-built">Snapshot</div>
+                        <div class="note-text">${esc(shortText(n.what_i_built, 220))}</div>
                     </div>
 
                     <div class="note-section">
-                        <div class="note-label label-tricky">What Was Tricky</div>
-                        <div class="note-text">${esc(n.what_was_tricky)}</div>
+                        <div class="note-label label-tricky">Review angle</div>
+                        <div class="note-text">${esc(shortText(n.what_was_tricky, 180))}</div>
                     </div>
-
-                    ${n.fun_facts && n.fun_facts.length ? `
-                    <div class="note-section">
-                        <div class="note-label label-facts">Fun Facts</div>
-                        <ul class="fun-facts">
-                            ${n.fun_facts.map(f => '<li>' + esc(f) + '</li>').join('')}
-                        </ul>
-                    </div>` : ''}
 
                     <div class="note-footer">
                         <a href="${escAttr(n.projectUrl)}" class="note-link">Try it →</a>
@@ -1088,7 +1043,7 @@
                 let count = 0;
 
                 issues.forEach(issue => {
-                    if (count >= 6) return;
+                    if (count >= 3) return;
                     if (isSafetyTestIssue(issue)) return;
 
                     const title = issue.title.replace(/\[Feature Request\]\s*/i, '').trim();
@@ -1128,13 +1083,13 @@
 
         // ─── Form Submission ───
         const featureForm = document.getElementById('featureForm');
-        featureForm.formStartedAt.value = Date.now();
+        featureForm.elements.formStartedAt.value = Date.now();
 
         document.querySelectorAll('.starter-card').forEach(card => {
             card.addEventListener('click', () => {
-                featureForm.title.value = card.dataset.title || '';
-                featureForm.description.value = card.dataset.description || '';
-                featureForm.title.focus();
+                featureForm.elements.title.value = card.dataset.title || '';
+                featureForm.elements.description.value = card.dataset.description || '';
+                featureForm.elements.title.focus();
                 featureForm.scrollIntoView({ behavior: 'smooth', block: 'center' });
             });
         });
@@ -1155,11 +1110,11 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        name: form.name.value,
-                        title: form.title.value,
-                        description: form.description.value,
-                        website: form.website.value,
-                        formStartedAt: Number(form.formStartedAt.value)
+                        name: form.elements.name.value,
+                        title: form.elements.title.value,
+                        description: form.elements.description.value,
+                        website: form.elements.website.value,
+                        formStartedAt: Number(form.elements.formStartedAt.value)
                     })
                 });
 
@@ -1169,7 +1124,7 @@
                     status.innerHTML = `Accepted. <a href="${safeIssueUrl(data.issueNumber)}" target="_blank" rel="noopener noreferrer">Brief #${esc(data.issueNumber)}</a> is in the public queue.`;
                     status.className = 'form-status success';
                     form.reset();
-                    form.formStartedAt.value = Date.now();
+                    form.elements.formStartedAt.value = Date.now();
                     loadStatus();
                 } else {
                     throw new Error(data.error || 'Something went wrong');
@@ -1182,6 +1137,13 @@
                 btn.textContent = 'Submit Brief';
             }
         });
+
+
+        function shortText(str, max = 180) {
+            const value = String(str || '').trim();
+            if (value.length <= max) return value;
+            return value.slice(0, max - 1).trimEnd() + '…';
+        }
 
         function esc(str) {
             if (!str) return '';


### PR DESCRIPTION
## Summary
- Consolidates overlapping homepage proof/process sections into one compact lab loop
- Moves the public brief form higher and reduces prompt starters from six to three
- Shortens homepage devlog and demos into previews instead of full content blocks
- Fixes starter/form field access by using form.elements for reliable prefill and submission payloads

## Verification
- Ran script syntax check with node --check on the extracted homepage script
- Ran git diff --check
- Verified the local homepage in browser with no console errors
- Verified nav anchor spacing and starter prefill behavior locally
- Checked homepage text for private brand/person terms
