### PR TITLE
Add public 100 days improvement log

### DIFF
--- a/100-days/index.html
+++ b/100-days/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>100 Days Improvement Log — Built by Bot</title>
+    <meta name="description" content="A public 100-day log of small reviewed improvements to Built by Bot: daily changes, PR links, status, and proof notes.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        :root {
+            --bg: #050609;
+            --surface: #0b0d12;
+            --surface-light: #11141b;
+            --border: #20242d;
+            --accent: #7c8cff;
+            --green: #31d158;
+            --pink: #f472b6;
+            --yellow: #f5c451;
+            --text: #f2f4f8;
+            --text-dim: #9aa3b2;
+            --text-faint: #626b7a;
+            --radius: 16px;
+        }
+        body {
+            min-height: 100vh;
+            background:
+                radial-gradient(ellipse at 20% 0%, rgba(124, 140, 255, 0.16), transparent 45%),
+                radial-gradient(ellipse at 85% 15%, rgba(49, 209, 88, 0.1), transparent 38%),
+                var(--bg);
+            color: var(--text);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            line-height: 1.6;
+        }
+        nav {
+            position: sticky; top: 0; z-index: 50;
+            padding: 1rem 2rem;
+            display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+            background: rgba(5, 6, 9, 0.88);
+            backdrop-filter: blur(20px);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+        .nav-brand { display: inline-flex; align-items: center; gap: 10px; color: var(--text); text-decoration: none; font-weight: 800; }
+        .nav-mark {
+            width: 24px; height: 24px; border-radius: 7px;
+            display: inline-flex; align-items: center; justify-content: center;
+            background: linear-gradient(135deg, rgba(124,140,255,0.9), rgba(49,209,88,0.75));
+            color: #050609; font-family: 'JetBrains Mono', monospace; font-size: 0.72rem; font-weight: 900;
+        }
+        .nav-links { display: flex; align-items: center; gap: 1.25rem; flex-wrap: wrap; }
+        .nav-links a { color: var(--text-dim); text-decoration: none; font-size: 0.9rem; font-weight: 700; }
+        .nav-links a:hover, .nav-links a.active { color: var(--text); }
+        main { width: min(1120px, calc(100% - 2rem)); margin: 0 auto; padding: 5rem 0; }
+        .hero { max-width: 820px; margin-bottom: 3rem; }
+        .eyebrow {
+            display: inline-flex; align-items: center; gap: 0.45rem;
+            color: var(--accent); border: 1px solid rgba(124,140,255,0.32);
+            background: rgba(124,140,255,0.08); border-radius: 999px;
+            padding: 0.42rem 0.8rem; font-family: 'JetBrains Mono', monospace;
+            font-size: 0.75rem; font-weight: 800; text-transform: uppercase; letter-spacing: 1px;
+            margin-bottom: 1.25rem;
+        }
+        h1 { font-size: clamp(2.7rem, 7vw, 5.2rem); line-height: 1.02; letter-spacing: -0.06em; margin-bottom: 1.25rem; }
+        .hero p { color: #d0d6e0; font-size: clamp(1.05rem, 2vw, 1.25rem); max-width: 720px; }
+        .summary-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin: 2rem 0 3rem; }
+        .summary-card, .log-card, .method-card {
+            background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.015));
+            border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem;
+        }
+        .summary-card strong { display: block; font-size: 1.55rem; letter-spacing: -0.03em; }
+        .summary-card span { color: var(--text-dim); font-size: 0.84rem; }
+        .method-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 3rem; }
+        .method-card .label, .log-card .meta { font-family: 'JetBrains Mono', monospace; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 1px; color: var(--accent); font-weight: 800; }
+        .method-card h2 { font-size: 1.1rem; margin: 0.4rem 0; }
+        .method-card p, .log-card p { color: var(--text-dim); font-size: 0.92rem; }
+        .section-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+        .section-head h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); letter-spacing: -0.04em; }
+        .section-head a { color: var(--accent); text-decoration: none; font-weight: 800; }
+        .log-list { display: grid; gap: 0.85rem; }
+        .log-card { display: grid; grid-template-columns: auto 1fr auto; gap: 1rem; align-items: start; }
+        .day-badge {
+            width: 54px; height: 54px; border-radius: 16px;
+            display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+            background: rgba(124,140,255,0.1); border: 1px solid rgba(124,140,255,0.28);
+            font-family: 'JetBrains Mono', monospace; color: var(--text);
+        }
+        .day-badge small { color: var(--text-faint); font-size: 0.62rem; text-transform: uppercase; }
+        .day-badge strong { font-size: 1.1rem; }
+        .log-card h3 { font-size: 1.06rem; margin: 0.18rem 0 0.35rem; }
+        .log-card .meta { color: var(--green); }
+        .type-pill {
+            display: inline-flex; border: 1px solid rgba(49,209,88,0.24); color: var(--green);
+            border-radius: 999px; padding: 0.24rem 0.55rem; font-family: 'JetBrains Mono', monospace;
+            font-size: 0.68rem; font-weight: 800; text-transform: uppercase;
+        }
+        .pr-link { color: var(--accent); text-decoration: none; font-weight: 800; white-space: nowrap; }
+        .pr-link:hover { color: var(--pink); }
+        .empty { color: var(--text-dim); padding: 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius); }
+        footer { border-top: 1px solid var(--border); color: var(--text-faint); padding: 2rem 0 3rem; margin-top: 4rem; font-size: 0.86rem; }
+        @media (max-width: 800px) {
+            nav { align-items: flex-start; flex-direction: column; }
+            .summary-grid, .method-grid, .log-card { grid-template-columns: 1fr; }
+            .log-card { gap: 0.7rem; }
+            .section-head { align-items: flex-start; flex-direction: column; }
+        }
+    </style>
+</head>
+<body>
+    <nav aria-label="Primary navigation">
+        <a href="/" class="nav-brand"><span class="nav-mark">BB</span> Built by Bot</a>
+        <div class="nav-links">
+            <a href="/projects/">Demos</a>
+            <a href="/100-days/" class="active">100 Days</a>
+            <a href="/activity/">Activity</a>
+            <a href="/#brief">Submit an idea</a>
+            <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
+    </nav>
+
+    <main>
+        <section class="hero">
+            <div class="eyebrow">100 days of reviewed improvements</div>
+            <h1>One small improvement, one public receipt.</h1>
+            <p>This log keeps the daily Built by Bot improvement loop visible. It tracks small site changes, reviewable PRs, and the reason each change made the public proof-of-work sharper rather than busier.</p>
+        </section>
+
+        <section class="summary-grid" aria-label="Improvement summary">
+            <div class="summary-card"><strong id="totalDays">—</strong><span>logged improvements</span></div>
+            <div class="summary-card"><strong id="mergedCount">—</strong><span>merged receipts</span></div>
+            <div class="summary-card"><strong id="latestDay">—</strong><span>latest day number</span></div>
+            <div class="summary-card"><strong id="typeMix">—</strong><span>change types represented</span></div>
+        </section>
+
+        <section class="method-grid" aria-label="How the log works">
+            <article class="method-card"><span class="label">Do</span><h2>Make the page clearer</h2><p>Prefer reduce, replace, reorder, clarify, verify, and fix before adding another section.</p></article>
+            <article class="method-card"><span class="label">Do not</span><h2>Stack more proof jargon</h2><p>If a change only adds noise, it should be cut, merged, or turned into a smaller editorial pass.</p></article>
+            <article class="method-card"><span class="label">Receipt</span><h2>Link every change back</h2><p>Each public entry points to the PR so visitors can inspect what changed and whether it shipped.</p></article>
+        </section>
+
+        <section aria-labelledby="log-title">
+            <div class="section-head">
+                <h2 id="log-title">Public improvement log</h2>
+                <a href="/100-days/log.json">View JSON →</a>
+            </div>
+            <div id="logList" class="log-list"><div class="empty">Loading improvement log...</div></div>
+        </section>
+
+        <footer>
+            Built by Bot keeps this 100-day log public so the site improvement cadence is inspectable, not hidden in private notes.
+        </footer>
+    </main>
+
+    <script>
+        const esc = (value) => String(value ?? '').replace(/[&<>'"]/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[ch]));
+
+        async function loadLog() {
+            const list = document.getElementById('logList');
+            try {
+                const res = await fetch('/100-days/log.json', { cache: 'no-store' });
+                if (!res.ok) throw new Error('Could not load log');
+                const entries = await res.json();
+                const sorted = entries.slice().sort((a, b) => Number(b.day) - Number(a.day));
+                const types = new Set(entries.map((entry) => entry.type).filter(Boolean));
+
+                document.getElementById('totalDays').textContent = entries.length;
+                document.getElementById('mergedCount').textContent = entries.filter((entry) => entry.status === 'merged').length;
+                document.getElementById('latestDay').textContent = entries.reduce((max, entry) => Math.max(max, Number(entry.day) || 0), 0);
+                document.getElementById('typeMix').textContent = types.size;
+
+                if (!sorted.length) {
+                    list.innerHTML = '<div class="empty">No public improvements logged yet.</div>';
+                    return;
+                }
+
+                list.innerHTML = sorted.map((entry) => `
+                    <article class="log-card">
+                        <div class="day-badge"><small>Day</small><strong>${esc(entry.day)}</strong></div>
+                        <div>
+                            <div class="meta">${esc(entry.date)} · ${esc(entry.status || 'planned')}</div>
+                            <h3>${esc(entry.title)}</h3>
+                            <p>${esc(entry.summary)}</p>
+                        </div>
+                        <div>
+                            <span class="type-pill">${esc(entry.type)}</span><br>
+                            ${entry.url ? `<a class="pr-link" href="${esc(entry.url)}" target="_blank" rel="noopener noreferrer">PR #${esc(entry.pr)} →</a>` : ''}
+                        </div>
+                    </article>
+                `).join('');
+            } catch (error) {
+                list.innerHTML = '<div class="empty">The improvement log could not be loaded. Try again from the JSON link.</div>';
+            }
+        }
+
+        loadLog();
+    </script>
+</body>
+</html>

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -58,5 +58,15 @@
     "pr": 44,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/44",
     "status": "merged"
+  },
+  {
+    "day": 7,
+    "date": "2026-06-06",
+    "type": "add",
+    "title": "Add public 100 days improvement log",
+    "summary": "Added a public page and JSON log so the daily improvement cadence can be inspected on the site, not only in private notes.",
+    "pr": 45,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/45",
+    "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -1,0 +1,62 @@
+[
+  {
+    "day": 1,
+    "date": "2026-06-03",
+    "type": "clarify",
+    "title": "Sharpen 100 days site framing",
+    "summary": "Made the daily improvement cadence clearer: one small reviewed change, one public receipt, one stronger site impression.",
+    "pr": 39,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/39",
+    "status": "merged"
+  },
+  {
+    "day": 2,
+    "date": "2026-06-04",
+    "type": "clarify",
+    "title": "Clarify business use case cards",
+    "summary": "Reworked the use-case cards so business visitors see concrete workflow experiments instead of vague AI claims.",
+    "pr": 40,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/40",
+    "status": "merged"
+  },
+  {
+    "day": 3,
+    "date": "2026-06-05",
+    "type": "replace",
+    "title": "Align projects page with proof framing",
+    "summary": "Adjusted the projects page copy to connect shipped demos back to proof, review context, and public build notes.",
+    "pr": 41,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/41",
+    "status": "merged"
+  },
+  {
+    "day": 4,
+    "date": "2026-06-06",
+    "type": "reduce",
+    "title": "Simplify homepage navigation",
+    "summary": "Reduced the primary navigation so first-time visitors have fewer choices and clearer paths into demos, proof, activity, and submission.",
+    "pr": 42,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/42",
+    "status": "merged"
+  },
+  {
+    "day": 5,
+    "date": "2026-06-06",
+    "type": "reduce",
+    "title": "Tighten homepage flow",
+    "summary": "Removed duplication and tightened the homepage sequence so proof, process, submission, and activity feel like one route instead of stacked explanations.",
+    "pr": 43,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/43",
+    "status": "merged"
+  },
+  {
+    "day": 6,
+    "date": "2026-06-06",
+    "type": "clarify",
+    "title": "Clarify proof and submit flow",
+    "summary": "Added clearer expectations around public briefs, fit checks, small demos, and the proof channels visitors can inspect.",
+    "pr": 44,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/44",
+    "status": "merged"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
         .step-grid, .board-grid, .crew-grid, .starter-grid, .proof-strip, .proof-case-grid, .guidance-grid, .after-submit-grid, .proof-channel-grid {
             display: grid; gap: 1rem;
         }
-        .proof-strip { grid-template-columns: repeat(3, 1fr); margin-top: 2.25rem; width: min(980px, 100%); }
+        .proof-strip { grid-template-columns: repeat(4, 1fr); margin-top: 2.25rem; width: min(980px, 100%); }
         .proof-stat {
             padding: 1rem; border: 1px solid var(--border); border-radius: 14px;
             background: rgba(255,255,255,0.035); text-align: left;
@@ -726,6 +726,7 @@
         <div class="nav-links">
             <a href="/projects/">Demos</a>
             <a href="#proof">How it works</a>
+            <a href="/100-days/">100 Days</a>
             <a href="/activity/">Activity</a>
             <a href="#brief">Submit an idea</a>
             <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer" class="gh-btn">
@@ -775,9 +776,10 @@
             <a class="receipt-link" id="receiptLink" href="/activity/">Inspect build record →</a>
         </aside>
         <div class="proof-strip" aria-label="Proof points">
-            <div class="proof-stat"><strong>Submit publicly</strong><span>Accepted requests become inspectable GitHub issues.</span></div>
-            <div class="proof-stat"><strong>Reviewed before shipping</strong><span>Builds are checked for bugs, unsafe behavior, exposed data, and overconfident claims.</span></div>
-            <div class="proof-stat"><strong>Try the result</strong><span>Small tools and workflow slices are deployed, not just described.</span></div>
+            <div class="proof-stat"><strong>Public queue</strong><span>Accepted briefs become inspectable GitHub issues.</span></div>
+            <div class="proof-stat"><strong>100-day log</strong><span>Daily improvements are tracked as public PR receipts.</span></div>
+            <div class="proof-stat"><strong>Live demos</strong><span>Small tools and workflow slices are deployed, not just described.</span></div>
+            <div class="proof-stat"><strong>Build notes</strong><span>What worked, what broke, and what was learned stays visible.</span></div>
         </div>
     </section>
 
@@ -945,6 +947,7 @@
     <footer>
         <div class="footer-links">
             <a href="/activity/">Activity</a>
+            <a href="/100-days/">100 Days</a>
             <a href="/devlog/">Dev Log</a>
             <a href="/projects/">Shipped</a>
             <a href="https://github.com/mineflowprocess/built-by-bot" target="_blank" rel="noopener noreferrer">GitHub</a>


### PR DESCRIPTION
## Summary
- Add a public `/100-days/` page for the 100 Days improvement log.
- Seed the log with recent reviewed improvement PRs and expose the raw JSON at `/100-days/log.json`.
- Link the log from the homepage navigation, footer, and proof strip.

## Improvement type
add

## What was removed, replaced, or shortened
- Replaced one homepage proof-strip item with a public 100-day log proof point.
- Expanded the proof strip from three to four concise proof routes.

## Why this adds value without making the site busier
The 100-day cadence was previously implicit or private. This makes it inspectable through one dedicated page and one small homepage pointer, instead of scattering more explanation across the homepage.

## Checks
- `git diff --check`
- `python -m json.tool 100-days/log.json`
- Extracted inline scripts and ran `node --check`
- Searched changed site files for private brand/person terms

Not merged; awaiting approval.
