### PR TITLE
fix: correct public log receipt status

### DIFF
--- a/100-days/log.json
+++ b/100-days/log.json
@@ -67,6 +67,16 @@
     "summary": "Added a public page and JSON log so the daily improvement cadence can be inspected on the site, not only in private notes.",
     "pr": 45,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/45",
+    "status": "merged"
+  },
+  {
+    "day": 8,
+    "date": "2026-06-07",
+    "type": "fix",
+    "title": "Correct public log receipt status",
+    "summary": "Corrected the latest public receipt status so visitors see an accurate merged count and a fresh reviewable PR entry without adding another homepage section.",
+    "pr": null,
+    "url": "",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -75,8 +75,8 @@
     "type": "fix",
     "title": "Correct public log receipt status",
     "summary": "Corrected the latest public receipt status so visitors see an accurate merged count and a fresh reviewable PR entry without adding another homepage section.",
-    "pr": null,
-    "url": "",
+    "pr": 46,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/46",
     "status": "open"
   }
 ]


### PR DESCRIPTION
## Summary
- Improvement type: fix
- Corrects the Day 7 public 100-days receipt from open to merged after PR #45 landed.
- Adds the Day 8 public 100-days log entry for this daily PR.
- Keeps the improvement editorial: no new homepage section, no extra card, just more accurate public proof.

## Removed, replaced, or shortened
- Replaced a stale open status with the accurate merged status.
- No page content was expanded.

## Why this adds value today
- The public 100-days page now reports the merged receipt count more accurately.
- It strengthens trust in the proof trail without making the site busier.

## Checks performed
- Parsed 100-days/log.json as valid JSON.
- Checked the diff for restricted public terms and sensitive-value-like strings.
- Ran git diff --check.
- Confirmed the GitHub artifact text is in English.

Not merged; awaiting approval.
