### PR TITLE
clarify: distinguish improvement log status

### DIFF
--- a/100-days/index.html
+++ b/100-days/index.html
@@ -89,11 +89,14 @@
         .day-badge strong { font-size: 1.1rem; }
         .log-card h3 { font-size: 1.06rem; margin: 0.18rem 0 0.35rem; }
         .log-card .meta { color: var(--green); }
-        .type-pill {
+        .type-pill, .status-pill {
             display: inline-flex; border: 1px solid rgba(49,209,88,0.24); color: var(--green);
             border-radius: 999px; padding: 0.24rem 0.55rem; font-family: 'JetBrains Mono', monospace;
             font-size: 0.68rem; font-weight: 800; text-transform: uppercase;
         }
+        .status-pill { margin-left: 0.45rem; border-color: rgba(124,140,255,0.28); color: var(--accent); }
+        .status-pill[data-status="merged"] { border-color: rgba(49,209,88,0.28); color: var(--green); }
+        .status-pill[data-status="open"] { border-color: rgba(245,196,81,0.35); color: var(--yellow); }
         .pr-link { color: var(--accent); text-decoration: none; font-weight: 800; white-space: nowrap; }
         .pr-link:hover { color: var(--pink); }
         .empty { color: var(--text-dim); padding: 1.5rem; border: 1px dashed var(--border); border-radius: var(--radius); }
@@ -177,7 +180,7 @@
                     <article class="log-card">
                         <div class="day-badge"><small>Day</small><strong>${esc(entry.day)}</strong></div>
                         <div>
-                            <div class="meta">${esc(entry.date)} · ${esc(entry.status || 'planned')}</div>
+                            <div class="meta">${esc(entry.date)} <span class="status-pill" data-status="${esc(entry.status || 'planned')}">${esc(entry.status || 'planned')}</span></div>
                             <h3>${esc(entry.title)}</h3>
                             <p>${esc(entry.summary)}</p>
                         </div>

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -85,8 +85,8 @@
     "type": "clarify",
     "title": "Clarify improvement log status",
     "summary": "Made open and merged receipt states easier to scan on the public improvement log without adding another section or card.",
-    "pr": 0,
-    "url": "",
+    "pr": 47,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/47",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -77,6 +77,16 @@
     "summary": "Corrected the latest public receipt status so visitors see an accurate merged count and a fresh reviewable PR entry without adding another homepage section.",
     "pr": 46,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/46",
+    "status": "merged"
+  },
+  {
+    "day": 9,
+    "date": "2026-06-08",
+    "type": "clarify",
+    "title": "Clarify improvement log status",
+    "summary": "Made open and merged receipt states easier to scan on the public improvement log without adding another section or card.",
+    "pr": 0,
+    "url": "",
     "status": "open"
   }
 ]


### PR DESCRIPTION
## Summary
- Improvement type: clarify
- Added compact status pills to the public 100 Days log so open and merged receipts are easier to scan.
- Updated the public 100-days log: PR #46 is now marked merged, and Day 9 records this improvement.

## Removed / replaced / shortened
- Replaced the plain inline status text with a small visual status pill.
- No new homepage section or extra content layer was added.

## Why this adds value today
- The improvement log now communicates proof status faster for business visitors.
- It makes the existing public proof-of-work page clearer without making the site busier.

## Checks performed
- Validated `100-days/log.json` with `python3 -m json.tool`.
- Checked the HTML markers for the log rendering change.
- Inspected the git diff.
- Scanned the diff for private brand/person terms and token-like values.
- Scanned the public worktree for private brand/person terms.
- Confirmed there were no open pull requests before creating this one.

Not merged; awaiting approval.
