### PR TITLE
fix: correct public log receipt status

### DIFF
--- a/100-days/log.json
+++ b/100-days/log.json
@@ -95,8 +95,8 @@
     "type": "fix",
     "title": "Fix public log receipt accuracy",
     "summary": "Corrected a stale receipt state and logged today's reviewable PR so visitors can trust the 100-day proof trail without adding more homepage content.",
-    "pr": null,
-    "url": "",
+    "pr": 48,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/48",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -87,6 +87,16 @@
     "summary": "Made open and merged receipt states easier to scan on the public improvement log without adding another section or card.",
     "pr": 47,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/47",
+    "status": "merged"
+  },
+  {
+    "day": 10,
+    "date": "2026-06-10",
+    "type": "fix",
+    "title": "Fix public log receipt accuracy",
+    "summary": "Corrected a stale receipt state and logged today's reviewable PR so visitors can trust the 100-day proof trail without adding more homepage content.",
+    "pr": null,
+    "url": "",
     "status": "open"
   }
 ]


### PR DESCRIPTION
## Summary
- Improvement type: fix
- Corrects the public 100-days log so PR #47 is marked as merged.
- Adds today's concise public 100-days log entry for this reviewable change.

## What changed
- Updated `/100-days/log.json` only.
- Kept the website route unchanged and avoided adding homepage content, cards, or sections.

## What was removed, replaced, or shortened
- Replaced the stale `open` status for PR #47 with `merged`.
- No new visual surface area was added.

## Why this adds value today without making the site busier
- The proof trail is more trustworthy because the public log now matches the actual PR state.
- The daily cadence remains visible through the existing 100-days page instead of adding another layer to the homepage.

## Checks performed
- Parsed `100-days/log.json` with `python3 -m json.tool`.
- Ran `git diff --check`.
- Reviewed the diff for sensitive-value-like strings and private brand/person references.
- Confirmed the change is data-only and does not introduce new scripts, forms, external dependencies, or user input paths.

Not merged; awaiting approval.
