### PR TITLE
clarify: sharpen reviewed demo gallery

### DIFF
--- a/100-days/log.json
+++ b/100-days/log.json
@@ -105,8 +105,8 @@
     "type": "clarify",
     "title": "Clarify reviewed demo gallery proof path",
     "summary": "Sharpened the project gallery language so visitors see demos as reviewed public builds with briefs, review trails, and live results when available.",
-    "pr": null,
-    "url": "",
+    "pr": 49,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/49",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -97,6 +97,16 @@
     "summary": "Corrected a stale receipt state and logged today's reviewable PR so visitors can trust the 100-day proof trail without adding more homepage content.",
     "pr": 48,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/48",
+    "status": "merged"
+  },
+  {
+    "day": 11,
+    "date": "2026-06-16",
+    "type": "clarify",
+    "title": "Clarify reviewed demo gallery proof path",
+    "summary": "Sharpened the project gallery language so visitors see demos as reviewed public builds with briefs, review trails, and live results when available.",
+    "pr": null,
+    "url": "",
     "status": "open"
   }
 ]

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Built by Bot — Reviewed demos</title>
+    <title>Built by Bot — Reviewed demo gallery</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -145,18 +145,18 @@
     <div class="container">
         <div class="header">
             <a href="/" class="back-link">← Back to home</a>
-            <h1>🦾 Reviewed demos</h1>
-            <p class="subtitle">Small shipped builds connected to public briefs and review context</p>
+            <h1>🦾 Reviewed demo gallery</h1>
+            <p class="subtitle">Small public builds with a brief, a review trail, and a live result when available</p>
         </div>
 
         <div class="stats">
             <div class="stat">
                 <div class="stat-value" id="totalProjects">-</div>
-                <div class="stat-label">Demos Shipped</div>
+                <div class="stat-label">Reviewed demos</div>
             </div>
             <div class="stat">
                 <div class="stat-value" id="inProgress">-</div>
-                <div class="stat-label">Queued or Building</div>
+                <div class="stat-label">Open briefs</div>
             </div>
         </div>
 
@@ -165,7 +165,8 @@
         </div>
 
         <div class="footer">
-            <a href="/">← Submit a scoped brief</a> ·
+            <a href="/">Submit a focused brief</a> ·
+            <a href="/100-days/">View the 100-day proof log</a> ·
             Powered by <a href="https://github.com/openclaw/openclaw">OpenClaw</a>
         </div>
     </div>
@@ -232,7 +233,7 @@
                 grid.innerHTML = projects.map(p => {
                     const statusText = p.status === 'done' ? '✓ Done' : '⏳ Building';
                     const issueLink = p.issueUrl
-                        ? `<a href="${esc(p.issueUrl)}" target="_blank" rel="noopener noreferrer">Issue #${esc(p.issue)}</a>`
+                        ? `<a href="${esc(p.issueUrl)}" target="_blank" rel="noopener noreferrer">Public brief #${esc(p.issue)}</a>`
                         : '';
                     const tryItLink = p.status === 'done' && p.projectUrl
                         ? `<a href="${esc(p.projectUrl)}" class="try-it">${esc('Try it →')}</a>`


### PR DESCRIPTION
## Summary
- Improvement type: clarify
- Clarifies the reviewed demo gallery so visitors see each project as a public build with a brief, review trail, and live result when available.
- Replaces generic project labels with proof-oriented wording: reviewed demos, open briefs, public brief links, and a direct path to the 100-day proof log.
- Updates the public 100-days log for today's reviewed change and corrects the previous receipt status.

## What changed without adding busyness
- Shortened and sharpened existing gallery copy instead of adding another homepage section or card.
- Reused the existing footer area for the proof-log path rather than creating new layout surface.

## Checks performed
- Reviewed git diff for scope and public safety.
- Validated JSON formatting for the public 100-days log.
- Parsed updated HTML files with Python's HTML parser.
- Scanned the changed files and diff for sensitive-value-like strings and disallowed public references.

Not merged; awaiting approval.
