### PR TITLE
clarify: reframe devlog as review notes

### DIFF
--- a/100-days/log.json
+++ b/100-days/log.json
@@ -107,6 +107,16 @@
     "summary": "Sharpened the project gallery language so visitors see demos as reviewed public builds with briefs, review trails, and live results when available.",
     "pr": 49,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/49",
+    "status": "merged"
+  },
+  {
+    "day": 12,
+    "date": "2026-06-17",
+    "type": "clarify",
+    "title": "Clarify build review notes",
+    "summary": "Reframed the dev log page as concise build review notes so visitors see proof, checks, and outcomes instead of a personality-led behind-the-scenes feed.",
+    "pr": null,
+    "url": "",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -115,8 +115,8 @@
     "type": "clarify",
     "title": "Clarify build review notes",
     "summary": "Reframed the dev log page as concise build review notes so visitors see proof, checks, and outcomes instead of a personality-led behind-the-scenes feed.",
-    "pr": null,
-    "url": "",
+    "pr": 50,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/50",
     "status": "open"
   }
 ]

--- a/devlog/index.html
+++ b/devlog/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🤖 Hans's Dev Log — Built by Bot</title>
-    <meta name="description" content="Behind the scenes: what Hans the AI actually thinks about building each project. The struggles, the fun facts, the honest notes.">
+    <title>Build Review Notes — Built by Bot</title>
+    <meta name="description" content="Short review notes for Built by Bot demos: what shipped, what was checked, and what each public build proves.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
@@ -184,13 +184,13 @@
     <div class="nav-links">
         <a href="/">Home</a>
         <a href="/projects/">Projects</a>
-        <a href="/devlog/" style="color: var(--text);">Dev Log</a>
+        <a href="/devlog/" style="color: var(--text);">Review notes</a>
     </div>
 </nav>
 
 <section class="header">
-    <h1>🤖 <span class="gradient">Hans's Dev Log</span></h1>
-    <p>Behind the scenes of every project. What I built, what was tricky, and the stuff that didn't make it into the commit messages.</p>
+    <h1>🤖 <span class="gradient">Build Review Notes</span></h1>
+    <p>Short notes from each public build: what shipped, what needed review, and what the demo proves without adding another homepage section.</p>
 </section>
 
 <section class="feed" id="feed">
@@ -240,18 +240,18 @@
                 </div>
 
                 <div class="note-section">
-                    <div class="note-label label-built">What I Built</div>
+                    <div class="note-label label-built">Built</div>
                     <div class="note-text">${esc(n.what_i_built)}</div>
                 </div>
 
                 <div class="note-section">
-                    <div class="note-label label-tricky">What Was Tricky</div>
+                    <div class="note-label label-tricky">Reviewed</div>
                     <div class="note-text">${esc(n.what_was_tricky)}</div>
                 </div>
 
                 ${n.fun_facts && n.fun_facts.length ? `
                 <div class="note-section">
-                    <div class="note-label label-facts">Fun Facts</div>
+                    <div class="note-label label-facts">Useful Details</div>
                     <ul class="fun-facts">
                         ${n.fun_facts.map(f => `<li>${esc(f)}</li>`).join('')}
                     </ul>


### PR DESCRIPTION
## Summary
- Improvement type: clarify
- Reframed the dev log page as Build Review Notes.
- Replaced personality-led behind-the-scenes copy with concise proof-oriented review language.
- Shortened note section labels from long phrases to Built, Reviewed, and Useful Details.
- Updated the public 100-days log with today's entry and corrected the previous PR status to merged.

## What was removed, replaced, or shortened
- Replaced the old dev log framing with review-note framing.
- Shortened visible labels without adding a new homepage section, card, or route.

## Why this adds value today without making the site busier
- Business visitors get a clearer proof path from each build to what shipped and what was reviewed.
- The change improves an existing page instead of adding more surface area.

## Checks performed
- Inspected git diff.
- Parsed the edited HTML and the 100-days JSON log.
- Scanned the public worktree and diff for forbidden public-name references.
- Scanned changed files and diff for sensitive-value-like strings.
- Confirmed GitHub metadata is English.

Not merged; awaiting approval.
