### PR TITLE
Clarify demo gallery status labels

### DIFF
--- a/100-days/log.json
+++ b/100-days/log.json
@@ -125,8 +125,8 @@
     "type": "clarify",
     "title": "Clarify demo gallery status labels",
     "summary": "Tightened the project gallery labels so visitors can distinguish published demos from queued briefs and find live demos faster without adding new cards.",
-    "pr": null,
-    "url": "",
+    "pr": 51,
+    "url": "https://github.com/mineflowprocess/built-by-bot/pull/51",
     "status": "open"
   }
 ]

--- a/100-days/log.json
+++ b/100-days/log.json
@@ -117,6 +117,16 @@
     "summary": "Reframed the dev log page as concise build review notes so visitors see proof, checks, and outcomes instead of a personality-led behind-the-scenes feed.",
     "pr": 50,
     "url": "https://github.com/mineflowprocess/built-by-bot/pull/50",
+    "status": "merged"
+  },
+  {
+    "day": 13,
+    "date": "2026-06-18",
+    "type": "clarify",
+    "title": "Clarify demo gallery status labels",
+    "summary": "Tightened the project gallery labels so visitors can distinguish published demos from queued briefs and find live demos faster without adding new cards.",
+    "pr": null,
+    "url": "",
     "status": "open"
   }
 ]

--- a/projects/index.html
+++ b/projects/index.html
@@ -94,8 +94,8 @@
             color: #27ca40;
         }
         .project-status.in-progress {
-            background: rgba(255, 193, 7, 0.2);
-            color: #ffc107;
+            background: rgba(102, 126, 234, 0.18);
+            color: #9aa8ff;
         }
         .project-description {
             color: #888;
@@ -152,11 +152,11 @@
         <div class="stats">
             <div class="stat">
                 <div class="stat-value" id="totalProjects">-</div>
-                <div class="stat-label">Reviewed demos</div>
+                <div class="stat-label">Published demos</div>
             </div>
             <div class="stat">
                 <div class="stat-value" id="inProgress">-</div>
-                <div class="stat-label">Open briefs</div>
+                <div class="stat-label">Queued briefs</div>
             </div>
         </div>
 
@@ -231,12 +231,12 @@
                 }
                 
                 grid.innerHTML = projects.map(p => {
-                    const statusText = p.status === 'done' ? '✓ Done' : '⏳ Building';
+                    const statusText = p.status === 'done' ? '✓ Published' : '→ Queued brief';
                     const issueLink = p.issueUrl
                         ? `<a href="${esc(p.issueUrl)}" target="_blank" rel="noopener noreferrer">Public brief #${esc(p.issue)}</a>`
                         : '';
                     const tryItLink = p.status === 'done' && p.projectUrl
-                        ? `<a href="${esc(p.projectUrl)}" class="try-it">${esc('Try it →')}</a>`
+                        ? `<a href="${esc(p.projectUrl)}" class="try-it">${esc('Try live demo →')}</a>`
                         : '';
 
                     return `


### PR DESCRIPTION
## Summary
- Improvement type: clarify
- Tightens the project gallery status language from generic state labels to visitor-facing labels: published demos, queued briefs, and try live demo.
- Softens the queued-brief badge color so it reads as a waiting state rather than an urgent warning.
- Updates the public 100-days log for today's reviewed change and corrects the previous merged receipt state.

## What was removed, replaced, or shortened
- Replaced generic labels like Done, Building, Reviewed demos, and Open briefs with clearer gallery terms.
- No new cards or sections were added.

## Why this adds value today without making the site busier
- The gallery now explains what visitors can inspect immediately versus what is still a queued public brief.
- This sharpens the proof path by changing existing words and badge styling instead of increasing page weight.

## Checks performed
- Parsed 100-days/log.json with Python JSON tooling.
- Ran node --check on the extracted projects page script.
- Ran git diff --check.
- Scanned the diff for private-name and sensitive-value-like strings.
- Reviewed the final diff for public-safe English wording.

Not merged; awaiting approval.
